### PR TITLE
Fix: network switching/repitative rpc calls/health check rpc for L2 / 

### DIFF
--- a/src/containers/home/Home.js
+++ b/src/containers/home/Home.js
@@ -14,54 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 import React, { memo } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
 import { Outlet } from 'react-router-dom'
-import { getFS_Saves, getFS_Info } from 'actions/fixedAction'
-
-import { fetchBalances } from 'actions/networkAction'
-
-import { selectAccountEnabled, selectActiveNetwork, selectBaseEnabled,selectChainIdChanged
-} from 'selectors'
-
 /******** COMPONENTS ********/
 import { PageTitle } from 'components/layout/PageTitle'
-
 /******** UTILS ********/
-import { POLL_INTERVAL } from 'util/constant'
-import useInterval from 'hooks/useInterval'
+import NotificationAlert from 'components/alert/Alert'
+import { Footer, Header } from 'components/layout'
+import NotificationBanner from 'components/notificationBanner'
+import ModalContainer from 'containers/modals'
 import useGoogleAnalytics from 'hooks/useGoogleAnalytics'
 import useNetwork from 'hooks/useNetwork'
-import { NETWORK } from 'util/network/network.util'
-import NotificationBanner from 'components/notificationBanner'
-import { Footer, Header } from 'components/layout'
-import ModalContainer from 'containers/modals'
-import NotificationAlert from 'components/alert/Alert'
 
-import { HomeContainer, HomeContent } from './styles'
 import { useOnboard } from 'hooks/useOnboard'
 import { useWalletConnect } from 'hooks/useWalletConnect'
 import useWalletSwitch from 'hooks/useWalletSwitch'
+import { HomeContainer, HomeContent } from './styles'
 
 const Home = () => {
-  const dispatch = useDispatch()
-  const activeNetwork = useSelector(selectActiveNetwork())
-  const accountEnabled = useSelector(selectAccountEnabled())
-  const baseEnabled = useSelector(selectBaseEnabled())
-
-  useInterval(() => {
-    if (accountEnabled /*== MetaMask is connected*/) {
-      if(baseEnabled) {
-        dispatch(fetchBalances()) // account specific
-      }
-      if (activeNetwork === NETWORK.ETHEREUM) {
-        dispatch(getFS_Info())   // account specific
-        dispatch(getFS_Saves()) // account specific
-      }
-    }
-  }, POLL_INTERVAL)
-
-
-
   useGoogleAnalytics(); // Invoking GA analysis page view hooks
   useOnboard()
   useNetwork()

--- a/src/containers/save/Save.tsx
+++ b/src/containers/save/Save.tsx
@@ -35,8 +35,17 @@ import { PlaceholderConnect } from 'components/global/placeholderConnect'
 import { ModalTypography } from 'components/global/modalTypography'
 import { Preloader } from 'components/dao/preloader'
 
-import { selectFixed, selectSetup, selectBalance, selectLayer } from 'selectors'
+import {
+  selectFixed,
+  selectSetup,
+  selectBalance,
+  selectLayer,
+  selectActiveNetwork,
+} from 'selectors'
 import styled from 'styled-components'
+import useInterval from 'hooks/useInterval'
+import { NETWORK } from 'util/network/network.util'
+import { POLL_INTERVAL } from 'util/constant'
 
 export const OutputLabel = styled(Typography).attrs({
   variant: 'title',
@@ -54,6 +63,7 @@ export const Description = styled(Typography).attrs({
 `
 
 const Save = () => {
+  const activeNetwork = useSelector(selectActiveNetwork())
   const layer = useSelector(selectLayer())
   const { stakeInfo } = useSelector(selectFixed())
   const { accountEnabled, netLayer, bobaFeeChoice, bobaFeePriceRatio } =
@@ -73,6 +83,15 @@ const Save = () => {
     dispatch(getFS_Info())
     getMaxTransferValue()
   }, [])
+
+  useInterval(() => {
+    if (accountEnabled /*== MetaMask is connected*/) {
+      if (activeNetwork === NETWORK.ETHEREUM) {
+        dispatch(getFS_Info()) // account specific
+        dispatch(getFS_Saves()) // account specific
+      }
+    }
+  }, POLL_INTERVAL)
 
   useEffect(() => {
     getMaxTransferValue()

--- a/src/containers/save/Save.tsx
+++ b/src/containers/save/Save.tsx
@@ -15,36 +15,33 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-import React, { useState, useEffect, useCallback } from 'react'
+/* 
+  @Stake
+    - Staking is only available on Boba L2 (Ethereum network) only.
+*/
+
+import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { getFS_Saves, getFS_Info } from 'actions/fixedAction'
+import { getFS_Info, getFS_Saves } from 'actions/fixedAction'
 import { openModal } from 'actions/uiAction'
 
 import * as S from './Save.styles'
 
 import Connect from 'containers/connect'
 
-import { toWei_String } from 'util/amountConvert'
-import networkService from 'services/networkService'
-import { BigNumber, utils } from 'ethers'
-import { Typography } from 'components/global/typography'
-import { Button } from 'components/global/button'
-import TransactionList from 'components/stake/transactionList'
-import { PlaceholderConnect } from 'components/global/placeholderConnect'
-import { ModalTypography } from 'components/global/modalTypography'
 import { Preloader } from 'components/dao/preloader'
+import { Button } from 'components/global/button'
+import { PlaceholderConnect } from 'components/global/placeholderConnect'
+import { Typography } from 'components/global/typography'
+import TransactionList from 'components/stake/transactionList'
+import { BigNumber, utils } from 'ethers'
+import networkService from 'services/networkService'
+import { toWei_String } from 'util/amountConvert'
 
-import {
-  selectFixed,
-  selectSetup,
-  selectBalance,
-  selectLayer,
-  selectActiveNetwork,
-} from 'selectors'
-import styled from 'styled-components'
 import useInterval from 'hooks/useInterval'
-import { NETWORK } from 'util/network/network.util'
+import { selectBalance, selectFixed, selectLayer, selectSetup } from 'selectors'
+import styled from 'styled-components'
 import { POLL_INTERVAL } from 'util/constant'
 
 export const OutputLabel = styled(Typography).attrs({
@@ -63,7 +60,6 @@ export const Description = styled(Typography).attrs({
 `
 
 const Save = () => {
-  const activeNetwork = useSelector(selectActiveNetwork())
   const layer = useSelector(selectLayer())
   const { stakeInfo } = useSelector(selectFixed())
   const { accountEnabled, netLayer, bobaFeeChoice, bobaFeePriceRatio } =
@@ -79,17 +75,17 @@ const Save = () => {
   })
 
   useEffect(() => {
-    dispatch(getFS_Saves())
-    dispatch(getFS_Info())
-    getMaxTransferValue()
-  }, [])
+    if (accountEnabled) {
+      dispatch(getFS_Saves())
+      dispatch(getFS_Info())
+      getMaxTransferValue()
+    }
+  }, [accountEnabled])
 
   useInterval(() => {
-    if (accountEnabled /*== MetaMask is connected*/) {
-      if (activeNetwork === NETWORK.ETHEREUM) {
-        dispatch(getFS_Info()) // account specific
-        dispatch(getFS_Saves()) // account specific
-      }
+    if (accountEnabled) {
+      dispatch(getFS_Info())
+      dispatch(getFS_Saves())
     }
   }, POLL_INTERVAL)
 

--- a/src/hooks/useGasWatcher.ts
+++ b/src/hooks/useGasWatcher.ts
@@ -20,7 +20,7 @@ import { GAS_POLL_INTERVAL } from 'util/constant'
  *
  * Gas Calculation
  *
-   Fetch gas savings & gas details.
+   Fetch gas savings (ONLY ETH MAINNET) & gas details.
    The l1 security fee is moved to the l2 fee
    const gasSavings = (Number(gas.gasL1) * (l2Fee - l1SecurityFee) / Number(gas.gasL2)) / l2Fee;
    The l1 security fee is directly deducted from the user's account
@@ -66,7 +66,7 @@ const useGasWatcher = () => {
         (l2Fee + l1SecurityFee)
       setSavings(gasSavings ? gasSavings : 0)
     }
-    // fetch savings only if network is ethereum and mainnet.
+    // Load gas savings only in case of ETHEREUM MAINNET
     if (
       activeNetwork === NETWORK.ETHEREUM &&
       activeNetworkType === NETWORK_TYPE.MAINNET &&

--- a/src/hooks/useWalletConnect.ts
+++ b/src/hooks/useWalletConnect.ts
@@ -1,4 +1,4 @@
-import { fetchTransactions, addTokenList } from 'actions/networkAction'
+import { addTokenList } from 'actions/networkAction'
 import {
   setConnect,
   setConnectBOBA,
@@ -52,6 +52,7 @@ export const useWalletConnect = () => {
         dispatch(openModal('noMetaMaskModal'))
         return false
       } else if (initialized === 'wrongnetwork') {
+        dispatch(openModal('wrongNetworkModal'))
         return false
       } else if (initialized === false) {
         dispatch(setEnableAccount(false))
@@ -61,7 +62,7 @@ export const useWalletConnect = () => {
         dispatch(setLayer(initialized))
         dispatch(setEnableAccount(true))
         dispatch(setWalletAddress(networkService.account))
-        dispatch(fetchTransactions())
+        // dispatch(fetchTransactions())
         dispatch(addTokenList())
         return true
       } else {

--- a/src/hooks/useWalletConnect.ts
+++ b/src/hooks/useWalletConnect.ts
@@ -62,7 +62,6 @@ export const useWalletConnect = () => {
         dispatch(setLayer(initialized))
         dispatch(setEnableAccount(true))
         dispatch(setWalletAddress(networkService.account))
-        // dispatch(fetchTransactions())
         dispatch(addTokenList())
         return true
       } else {

--- a/src/hooks/useWalletSwitch.ts
+++ b/src/hooks/useWalletSwitch.ts
@@ -1,14 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-
 import { openModal } from 'actions/uiAction'
-import {
-  setBaseState,
-  setEnableAccount,
-  setConnect,
-  setConnectBOBA,
-  setConnectETH,
-} from 'actions/setupAction'
+import { setConnect, setConnectBOBA, setConnectETH } from 'actions/setupAction'
 
 import { setActiveNetwork } from 'actions/networkAction'
 
@@ -20,14 +13,12 @@ import {
   selectBaseEnabled,
   selectLayer,
   selectAccountEnabled,
-  selectSetup,
 } from 'selectors'
 
 import { LAYER } from 'util/constant'
 
 const useWalletSwitch = () => {
   const dispatch = useDispatch<any>()
-  const walletInfo = useSelector(selectSetup())
   const accountEnabled = useSelector(selectAccountEnabled())
   const network = useSelector(selectNetwork())
   const activeNetwork = useSelector(selectActiveNetwork())
@@ -55,9 +46,7 @@ const useWalletSwitch = () => {
   useEffect(() => {
     if (accountEnabled) {
       if (activeNetwork !== network || activeNetworkType !== networkType) {
-        dispatch(setActiveNetwork())
-        dispatch(setBaseState(false))
-        dispatch(setEnableAccount(false))
+        dispatch(openModal('switchNetworkModal'))
       }
     }
   }, [activeNetwork, activeNetworkType, network, networkType, dispatch])

--- a/src/hooks/useWalletSwitch.ts
+++ b/src/hooks/useWalletSwitch.ts
@@ -1,7 +1,13 @@
 import { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { openModal } from 'actions/uiAction'
-import { setConnect, setConnectBOBA, setConnectETH } from 'actions/setupAction'
+import {
+  setBaseState,
+  setConnect,
+  setConnectBOBA,
+  setConnectETH,
+  setEnableAccount,
+} from 'actions/setupAction'
 
 import { setActiveNetwork } from 'actions/networkAction'
 
@@ -47,6 +53,12 @@ const useWalletSwitch = () => {
     if (accountEnabled) {
       if (activeNetwork !== network || activeNetworkType !== networkType) {
         dispatch(openModal('switchNetworkModal'))
+      }
+    } else {
+      if (activeNetwork !== network || activeNetworkType !== networkType) {
+        dispatch(setActiveNetwork())
+        dispatch(setBaseState(false))
+        dispatch(setEnableAccount(false))
       }
     }
   }, [activeNetwork, activeNetworkType, network, networkType, dispatch])

--- a/src/services/gas.service.js
+++ b/src/services/gas.service.js
@@ -1,33 +1,31 @@
-
-
 import { logAmount } from "util/amountConvert";
 import networkService from "./networkService";
-
-
 class GasService {
 
   /**
    * @getGas
+   *  Fetchs latest gas price & block number of (L1/L2) for currently selected active network.
+   * 
   */
 
   async getGas() {
     try {
       // get gas price
-      const gasPrice1 = await networkService.L1Provider.getGasPrice()
-      const gasPrice2 = await networkService.L2Provider.getGasPrice()
+      const feeDataL1 = await networkService.L1Provider.getFeeData()
+      const feeDataL2 = await networkService.L2Provider.getFeeData()
       // get block count
       const block1 = await networkService.L1Provider.getBlockNumber()
       const block2 = await networkService.L2Provider.getBlockNumber()
 
       const gasData = {
-        gasL1: Number(logAmount(gasPrice1.toString(),9)).toFixed(0),
-        gasL2: Number(logAmount(gasPrice2.toString(),9)).toFixed(0),
+        gasL1: Number(logAmount(feeDataL1.gasPrice.toString(), 9)).toFixed(0),
+        gasL2: Number(logAmount(feeDataL2.gasPrice.toString(), 9)).toFixed(0),
         blockL1: Number(block1),
         blockL2: Number(block2),
       }
       return gasData
     } catch (error) {
-      console.log("GS: getGas error:",error)
+      console.log("GS: getGas", error)
       return error
     }
   }

--- a/src/services/networkService.js
+++ b/src/services/networkService.js
@@ -402,9 +402,15 @@ class NetworkService {
         activeL1RpcURL
       )
 
-      this.L2Provider = new ethers.providers.StaticJsonRpcProvider(
-        networkDetail['L2']['rpcUrl']
-      )
+      let activeL2RpcURL = networkDetail[ 'L2' ][ 'rpcUrl' ][ 0 ]
+      for (const rpcURL of networkDetail[ 'L2' ][ 'rpcUrl' ]) {
+        if (await pingRpcUrl(rpcURL)) {
+          activeL1RpcURL = rpcURL
+          break
+        }
+      }
+
+      this.L2Provider = new ethers.providers.StaticJsonRpcProvider(activeL2RpcURL)
 
       this.L1NativeTokenSymbol = networkDetail['L1']['symbol']
       this.L1NativeTokenName = networkDetail['L1']['tokenName'] || this.L1NativeTokenSymbol
@@ -438,7 +444,6 @@ class NetworkService {
       }
 
       this.addresses = addresses
-      console.log("LOADED ADDRESSES", this.addresses)
 
       // this.AddressManagerAddress = nw[networkGateway].addressManager
       // console.log("AddressManager address:",this.AddressManagerAddress)

--- a/src/util/constant.ts
+++ b/src/util/constant.ts
@@ -91,20 +91,13 @@ export const ROUTES_PATH: RoutesPathType = {
 export const PER_PAGE: number = 8
 
 type Network = 'ethereum' | 'bnb' | 'avax' //we move this to global network type once we define this
-type Page =
-  | 'Bridge'
-  | 'Wallet'
-  | 'History'
-  | 'Earn'
-  | 'Stake'
-  | 'DAO'
-  | 'Monster'
+type Page = 'Bridge' | 'History' | 'Earn' | 'Stake' | 'DAO' | 'Monster'
 type PagesByNetworkType = Record<Network, Page[]>
 
 export const PAGES_BY_NETWORK: PagesByNetworkType = {
-  ethereum: ['Bridge', 'Wallet', 'History', 'Earn', 'Stake', 'DAO'],
-  bnb: ['Bridge', 'Wallet', 'Earn', 'History'],
-  avax: ['Bridge', 'Wallet', 'Earn', 'History'],
+  ethereum: ['Bridge', 'History', 'Earn', 'Stake', 'DAO'],
+  bnb: ['Bridge', 'Earn', 'History'],
+  avax: ['Bridge', 'Earn', 'History'],
 }
 
 export enum Layer {

--- a/src/util/network/config/avax.js
+++ b/src/util/network/config/avax.js
@@ -3,8 +3,8 @@ export const avaxConfig = {
   Testnet: {
     OMGX_WATCHER_URL: `https://api-watcher.testnet.avax.boba.network/`,
     META_TRANSACTION: `https://api-meta-transaction.testnet.avax.boba.network/`,
-    MM_Label:         `Boba Avalanche Testnet`,
-    addressManager:   `0xcE78de95b85212BC348452e91e0e74c17cf37c79`,
+    MM_Label: `Boba Avalanche Testnet`,
+    addressManager: `0xcE78de95b85212BC348452e91e0e74c17cf37c79`,
     L1: {
       name: "Avalanche Testnet",
       chainId: 43113,
@@ -22,7 +22,9 @@ export const avaxConfig = {
       name: "Boba Avalanche Testnet",
       chainId: 4328,
       chainIdHex: '0x10E8',
-      rpcUrl: `https://testnet.avax.boba.network`,
+      rpcUrl: [
+        `https://testnet.avax.boba.network`
+      ],
       blockExplorer: `https://blockexplorer.testnet.avax.boba.network/`,
       transaction: `https://blockexplorer.testnet.avax.boba.network/tx/`,
       blockExplorerUrl: `https://blockexplorer.testnet.avax.boba.network/`,
@@ -35,8 +37,8 @@ export const avaxConfig = {
   Mainnet: {
     OMGX_WATCHER_URL: `https://api-watcher.avax.boba.network/`,
     META_TRANSACTION: `https://api-meta-transaction.avax.boba.network/`,
-    MM_Label:         `Boba Avalanche Mainnet`,
-    addressManager:   `0x00220f8ce1c4be8436574e575fE38558d85e2E6b`,
+    MM_Label: `Boba Avalanche Mainnet`,
+    addressManager: `0x00220f8ce1c4be8436574e575fE38558d85e2E6b`,
     L1: {
       name: "Avalanche Mainnet",
       chainId: 43114,
@@ -55,7 +57,7 @@ export const avaxConfig = {
       name: "Boba Avalanche Mainnet",
       chainId: 43288,
       chainIdHex: '0xA918',
-      rpcUrl: `https://avax.boba.network`,
+      rpcUrl: [ `https://avax.boba.network`, ],
       blockExplorer: `https://blockexplorer.avax.boba.network/`,
       transaction: `https://blockexplorer.avax.boba.network/tx/`,
       blockExplorerUrl: `https://blockexplorer.avax.boba.network`,

--- a/src/util/network/config/bnb.js
+++ b/src/util/network/config/bnb.js
@@ -10,6 +10,7 @@ export const bnbConfig = {
       chainId: 97,
       chainIdHex: '0x61',
       rpcUrl: [
+        `https://bsc-testnet.publicnode.com`,
         `https://data-seed-prebsc-1-s1.binance.org:8545`,
         `https://data-seed-prebsc-2-s1.binance.org:8545`,
         `https://bsc-testnet.public.blastapi.io`,
@@ -24,8 +25,8 @@ export const bnbConfig = {
       chainId: 9728,
       chainIdHex: '0x2600',
       rpcUrl: [
-        `https://boba-bnb-testnet.gateway.tenderly.co/1clfZoq7qEGyF4SQvF8gvI`,
         `https://testnet.bnb.boba.network`,
+        `https://boba-bnb-testnet.gateway.tenderly.co/1clfZoq7qEGyF4SQvF8gvI`,
         `https://replica.testnet.bnb.boba.network`
       ],
       blockExplorer: `https://testnet.bobascan.com/`,

--- a/src/util/network/config/ethereum.js
+++ b/src/util/network/config/ethereum.js
@@ -22,7 +22,7 @@ export const ethereumConfig = {
       name: "BOBA Goerli L2",
       chainId: 2888,
       chainIdHex: '0xB48',
-      rpcUrl: `https://goerli.boba.network`,
+      rpcUrl: [ `https://goerli.boba.network` ],
       blockExplorer: `https://testnet.bobascan.com/`,
       transaction: `https://testnet.bobascan.com/tx/`,
       blockExplorerUrl: `https://testnet.bobascan.com/`,


### PR DESCRIPTION
:clipboard: Add associated issues, tickets, docs URL here.

closes: 

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- fix: Eliminated redundant calls from the home component by relocating get balances/getFsInfo/get_Saves to a dedicated component.
- add: Loading Fs Info & Save on certain interval from save page for ETH network only
- chore: Comment update for use gas watcher.
- fix: Open wrong network modal when initializeAccount returns response `wrongnetwork`
- fix: open switch network modal when active network changes
- refactor: gas service to use getGasData instead of getGasPrice as it's deprecated.
- fix: Extended RPC Url Health Check for L2 providers too.
- fix: Updated the config for L2 rpc urls as list instead of string to support health check.
- refactor: cleanup commented code
- fix: network switching with/without connecting to MM
- 
## Testing

Describe how to test your new feature/bug fix and if possible, a step by step guide on how to demo this.
