### PR TITLE
Fix glitch in network switching MM <-> Gateway

### DIFF
--- a/src/containers/earn/Earn.js
+++ b/src/containers/earn/Earn.js
@@ -16,45 +16,44 @@
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import React, { useState, useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux';
+import React,{useEffect,useState} from 'react';
+import {useDispatch,useSelector} from 'react-redux';
 
-import { HelpOutline } from '@mui/icons-material'
+import {HelpOutline} from '@mui/icons-material';
 
 import {
-  selectUserInfo,
-  selectPoolInfo,
-  selectlayer1Balance,
-  selectlayer2Balance,
-  selectBaseEnabled,
   selectAccountEnabled,
-  selectLayer,
   selectActiveNetworkName,
-  selectChainIdChanged
-} from 'selectors'
+  selectBaseEnabled,
+  selectLayer,
+  selectPoolInfo,
+  selectUserInfo,
+  selectlayer1Balance,
+  selectlayer2Balance
+} from 'selectors';
 
-import { getEarnInfo } from 'actions/earnAction'
+import {getEarnInfo} from 'actions/earnAction';
 
-import Connect from 'containers/connect'
+import Connect from 'containers/connect';
 
-import ListEarn from 'components/listEarn/ListEarn'
-import AlertIcon from 'components/icons/AlertIcon'
+import Button from 'components/button/Button';
+import AlertIcon from 'components/icons/AlertIcon';
+import ListEarn from 'components/listEarn/ListEarn';
 import Tooltip from 'components/tooltip/Tooltip';
-import Button from 'components/button/Button'
 
-import networkService from 'services/networkService'
+import networkService from 'services/networkService';
 
-import * as S from './styles'
-import { fetchBalances } from 'actions/networkAction';
+import {fetchBalances} from 'actions/networkAction';
+import * as S from './styles';
 
-import { TableHeader } from 'components/global/table'
-import { CheckboxWithLabel } from 'components/global/checkbox'
-import { tableHeaderOptions } from './consts'
-import { Typography } from 'components/global/typography'
-import { toLayer } from './types'
+import {CheckboxWithLabel} from 'components/global/checkbox';
+import {TableHeader} from 'components/global/table';
+import {Typography} from 'components/global/typography';
+import {tableHeaderOptions} from './consts';
+import {toLayer} from './types';
 
-import { BridgeTooltip } from './tooltips'
-import { setConnectBOBA, setConnectETH } from 'actions/setupAction';
+import {setConnectBOBA,setConnectETH} from 'actions/setupAction';
+import {BridgeTooltip} from './tooltips';
 
 const Earn = () => {
   const dispatch = useDispatch();
@@ -70,7 +69,6 @@ const Earn = () => {
 
   const baseEnabled = useSelector(selectBaseEnabled())
   const accountEnabled = useSelector(selectAccountEnabled())
-  const chainIdChanged = useSelector(selectChainIdChanged())
   const networkName = useSelector(selectActiveNetworkName())
 
   const [showMDO, setShowMDO] = useState(false)

--- a/src/hooks/useDisconnect.js
+++ b/src/hooks/useDisconnect.js
@@ -1,4 +1,4 @@
-import { useDispatch } from 'react-redux';
+import {useDispatch,useSelector} from 'react-redux';
 import {
   setLayer,
   setConnect,
@@ -9,9 +9,14 @@ import {
 } from 'actions/setupAction';
 
 import networkService from 'services/networkService';
+import {useEffect} from 'react';
+import {selectChainIdChanged} from 'selectors';
+import {setActiveNetwork,setActiveNetworkType,setNetwork} from 'actions/networkAction';
+import {CHAIN_ID_LIST,NETWORK_TYPE,NetworkList} from 'util/network/network.util';
 
 const useDisconnect = () => {
   const dispatch = useDispatch();
+  const chainIdChanged = useSelector(selectChainIdChanged())
 
   const disconnect = async () => {
     await networkService.walletService.disconnectWallet()
@@ -23,7 +28,41 @@ const useDisconnect = () => {
     dispatch(setEnableAccount(false))
   }
 
-  return { disconnect }
+  useEffect(() => {
+
+    const switchChain = () => {
+      const {networkType,chain} = CHAIN_ID_LIST[Number(chainIdChanged)]
+      const {
+        chain: network,
+        icon: networkIcon,
+        name
+      } = NetworkList[networkType].find(network => network.chain === chain);
+
+      dispatch(setActiveNetworkType({networkType}))
+      dispatch(
+        setNetwork({
+          networkType,
+          network,
+          networkIcon,
+          name
+        })
+      )
+      dispatch(setActiveNetwork())
+    }
+
+    const disconnectAndSwitch = async () => {
+      // on changing network from metamask disconnect wallet,
+      // restart connect flow again with new network by updating state.
+      if (chainIdChanged) {
+        await disconnect();
+        switchChain();
+      } 
+    }
+
+    disconnectAndSwitch()
+  },[chainIdChanged,disconnect])
+
+  return {disconnect}
 }
 
 export default useDisconnect

--- a/src/hooks/useWalletConnect.ts
+++ b/src/hooks/useWalletConnect.ts
@@ -19,7 +19,6 @@ import {
   selectConnectETH,
   selectConnectBOBA,
   selectConnect,
-  selectChainIdChanged,
 } from 'selectors'
 import networkService from 'services/networkService'
 import { DISABLE_WALLETCONNECT, LAYER } from 'util/constant'
@@ -36,7 +35,6 @@ export const useWalletConnect = () => {
   const connectETHRequest = useSelector(selectConnectETH())
   const connectBOBARequest = useSelector(selectConnectBOBA())
   const connectRequest = useSelector(selectConnect())
-  const chainIdChanged = useSelector(selectChainIdChanged())
 
   /**
    * @triggerInit
@@ -45,9 +43,7 @@ export const useWalletConnect = () => {
 
   const triggerInit = useCallback(() => {
     const initAccount = async () => {
-      const initialized = await networkService.initializeAccount({
-        chainIdChanged,
-      })
+      const initialized = await networkService.initializeAccount()
       if (initialized === 'nometamask') {
         dispatch(openModal('noMetaMaskModal'))
         return false
@@ -69,17 +65,10 @@ export const useWalletConnect = () => {
       }
     }
 
-    if ((!accountEnabled && baseEnabled) || chainIdChanged) {
+    if (!accountEnabled && baseEnabled) {
       initAccount()
     }
-  }, [
-    dispatch,
-    accountEnabled,
-    network,
-    networkType,
-    baseEnabled,
-    chainIdChanged,
-  ])
+  }, [dispatch, accountEnabled, network, networkType, baseEnabled])
 
   // do connect layer.
   const doConnectToLayer = useCallback(

--- a/src/reducers/setupReducer.js
+++ b/src/reducers/setupReducer.js
@@ -31,7 +31,7 @@ const initialState = {
   connectBOBA: false,
   connect: false,
   walletConnected: false,
-  chainIdChanged: false,
+  chainIdChanged: null,
   networkChanged: false,
 }
 
@@ -111,7 +111,7 @@ function setupReducer(state = initialState, action) {
     case 'SETUP/CHAINIDCHANGED/RESET':
       return {
         ...state,
-        chainIdChanged: false
+        chainIdChanged: null
       }
     default:
       return state

--- a/src/services/networkService.js
+++ b/src/services/networkService.js
@@ -627,7 +627,7 @@ class NetworkService {
     }
   }
 
-  async initializeAccount({chainIdChanged}) {
+  async initializeAccount() {
 
     try {
 
@@ -642,10 +642,7 @@ class NetworkService {
       this.chainId = (await this.provider.getNetwork()).chainId
       this.account = await this.provider.getSigner().getAddress()
 
-      let chainId = chainIdChanged
-      if (!chainId) {
-        chainId = await this.provider.getNetwork().then(nt => nt.chainId)
-      }
+      let chainId = await this.provider.getNetwork().then(nt => nt.chainId)
 
       // defines the set of possible networks along with chainId for L1 and L2
       const networkDetail = getNetworkDetail({

--- a/src/services/wallet.service.js
+++ b/src/services/wallet.service.js
@@ -66,22 +66,7 @@ limitations under the License. */
 
     window.ethereum.on('chainChanged', (chainId) => {
       if (CHAIN_ID_LIST[Number(chainId)]) {
-        const { networkType, chain } = CHAIN_ID_LIST[Number(chainId)]
-        const {
-          chain: network,
-          icon: networkIcon,
-          name
-        } = NetworkList[ networkType ].find(network => network.chain === chain);
-        store.dispatch({ type: 'SETUP/CHAINIDCHANGED/SET', payload: Number(chainId) })
-        store.dispatch(
-          setNetwork({
-            networkType,
-            network,
-            networkIcon,
-            name
-          })
-        )
-        store.dispatch(setActiveNetwork())
+        store.dispatch({type: 'SETUP/CHAINIDCHANGED/SET',payload: Number(chainId)})
       } else {
         store.dispatch(openModal('UnsupportedNetwork'))
       }


### PR DESCRIPTION
:clipboard: Add associated issues, tickets, docs URL here.

closes: https://github.com/bobanetwork/boba/issues/1186
closes: https://github.com/bobanetwork/boba/issues/1168

## Overview

Describe what your Pull Request is about in a few sentences.

## Changes

- fix: switching network from MM trigger disconnect and reset active network
- fix: should update active network type on gateway based on the selected network from MM
- fix: cleanup initializeAccount, removed use `chainIdChanged`
- fix: trigger disconnect on `chanIdChanged` from MM and update the active network so the user can directly accept the modal from MM on connect button click

## Testing

Open the gateway, play around connect and disconnect feature to MM and try changing network gateway should disconnect the wallet and reset the application to user selected network 
