### PR TITLE
Hooks - useWalletConnect - unit tests 

### DIFF
--- a/src/hooks/useWalletConnect/index.test.tsx
+++ b/src/hooks/useWalletConnect/index.test.tsx
@@ -14,15 +14,12 @@ jest.mock('services/networkService', () => ({
   initializeAccount: jest.fn(),
   walletService: jest.fn(),
   switchChain: jest.fn(),
-  addTokenList: jest.fn(),
 }))
 
 describe('useWalletConnect', () => {
-  let dispatchMock
   let useSelectorMock
 
   beforeEach(() => {
-    dispatchMock = jest.fn()
     useSelectorMock = jest.fn()
   })
 

--- a/src/hooks/useWalletConnect/index.test.tsx
+++ b/src/hooks/useWalletConnect/index.test.tsx
@@ -14,6 +14,7 @@ jest.mock('services/networkService', () => ({
   initializeAccount: jest.fn(),
   walletService: jest.fn(),
   switchChain: jest.fn(),
+  addTokenList: jest.fn(),
 }))
 
 describe('useWalletConnect', () => {
@@ -267,7 +268,7 @@ describe('useWalletConnect', () => {
 
     jest
       .spyOn(networkService, 'initializeAccount')
-      .mockResolvedValueOnce('other')
+      .mockResolvedValueOnce(undefined)
 
     const store = mockStore(initialState)
     const wrapper = ({ children }) => (

--- a/src/hooks/useWalletConnect/index.test.tsx
+++ b/src/hooks/useWalletConnect/index.test.tsx
@@ -1,0 +1,349 @@
+import React from 'react'
+import { renderHook, act } from '@testing-library/react-hooks'
+import { useWalletConnect } from './'
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import { mockedInitialState } from 'util/tests'
+import { Provider } from 'react-redux'
+import { AnyAction } from 'redux'
+import networkService from 'services/networkService'
+import { LAYER } from 'util/constant'
+
+jest.mock('services/networkService', () => ({
+  ...jest.requireActual('services/networkService'),
+  initializeAccount: jest.fn(),
+  walletService: jest.fn(),
+  switchChain: jest.fn(),
+}))
+
+describe('useWalletConnect', () => {
+  let dispatchMock
+  let useSelectorMock
+
+  beforeEach(() => {
+    dispatchMock = jest.fn()
+    useSelectorMock = jest.fn()
+  })
+
+  const middlewares = [thunk]
+  const mockStore = configureMockStore(middlewares)
+
+  test('Layer L1/L2 should triggerInit if accountEnable is false and baseEnabled is true', async () => {
+    useSelectorMock.mockReturnValueOnce(false)
+
+    const initialState = {
+      ...mockedInitialState,
+      setup: {
+        ...mockedInitialState.setup,
+        baseEnabled: true,
+        accountEnabled: false,
+        netLayer: LAYER.L1,
+      },
+    }
+
+    jest
+      .spyOn(networkService, 'initializeAccount')
+      .mockResolvedValueOnce('nometamask')
+
+    const store = mockStore(initialState)
+    const wrapper = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    await act(async () => {
+      renderHook(() => useWalletConnect(), {
+        wrapper,
+      })
+    })
+
+    const actions: AnyAction[] = store.getActions()
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toEqual({
+      type: 'UI/MODAL/OPEN',
+      payload: 'noMetaMaskModal',
+    })
+  })
+
+  test('Layer L1/L2 should triggerInit if accountEnable is true and baseEnabled is true but chain has been changed', async () => {
+    useSelectorMock.mockReturnValueOnce(false)
+
+    const initialState = {
+      ...mockedInitialState,
+      setup: {
+        ...mockedInitialState.setup,
+        baseEnabled: true,
+        accountEnabled: true,
+        userTriggeredChainSwitch: true,
+        netLayer: LAYER.L1,
+      },
+    }
+
+    jest
+      .spyOn(networkService, 'initializeAccount')
+      .mockResolvedValueOnce('nometamask')
+
+    const store = mockStore(initialState)
+    const wrapper = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    await act(async () => {
+      renderHook(() => useWalletConnect(), {
+        wrapper,
+      })
+    })
+
+    const actions: AnyAction[] = store.getActions()
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toEqual({
+      type: 'UI/MODAL/OPEN',
+      payload: 'noMetaMaskModal',
+    })
+  })
+
+  test('triggerInit should Open No Metamask Modal when intialized === nometamask', async () => {
+    useSelectorMock.mockReturnValueOnce(false)
+
+    const initialState = {
+      ...mockedInitialState,
+      setup: {
+        ...mockedInitialState.setup,
+        baseEnabled: true,
+        accountEnabled: true,
+        userTriggeredChainSwitch: true,
+        netLayer: LAYER.L1,
+      },
+    }
+
+    jest
+      .spyOn(networkService, 'initializeAccount')
+      .mockResolvedValueOnce('nometamask')
+
+    const store = mockStore(initialState)
+    const wrapper = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    await act(async () => {
+      renderHook(() => useWalletConnect(), {
+        wrapper,
+      })
+    })
+
+    const actions: AnyAction[] = store.getActions()
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toEqual({
+      type: 'UI/MODAL/OPEN',
+      payload: 'noMetaMaskModal',
+    })
+  })
+
+  test('triggerInit should Open Wrong Network Modal when intialized === wrongnetwork', async () => {
+    useSelectorMock.mockReturnValueOnce(false)
+
+    const initialState = {
+      ...mockedInitialState,
+      setup: {
+        ...mockedInitialState.setup,
+        baseEnabled: true,
+        accountEnabled: true,
+        userTriggeredChainSwitch: true,
+        netLayer: LAYER.L1,
+      },
+    }
+
+    jest
+      .spyOn(networkService, 'initializeAccount')
+      .mockResolvedValueOnce('wrongnetwork')
+
+    const store = mockStore(initialState)
+    const wrapper = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    await act(async () => {
+      renderHook(() => useWalletConnect(), {
+        wrapper,
+      })
+    })
+
+    const actions: AnyAction[] = store.getActions()
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toEqual({
+      type: 'UI/MODAL/OPEN',
+      payload: 'wrongNetworkModal',
+    })
+  })
+
+  test('triggerInit should Set account enabled False when intialized === false', async () => {
+    useSelectorMock.mockReturnValueOnce(false)
+
+    const initialState = {
+      ...mockedInitialState,
+      setup: {
+        ...mockedInitialState.setup,
+        baseEnabled: true,
+        accountEnabled: true,
+        userTriggeredChainSwitch: true,
+        netLayer: LAYER.L1,
+      },
+    }
+
+    jest.spyOn(networkService, 'initializeAccount').mockResolvedValueOnce(false)
+
+    const store = mockStore(initialState)
+    const wrapper = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    await act(async () => {
+      renderHook(() => useWalletConnect(), {
+        wrapper,
+      })
+    })
+
+    const actions: AnyAction[] = store.getActions()
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toEqual({
+      type: 'SETUP/ACCOUNT/SET',
+      payload: false,
+    })
+  })
+
+  test('triggerInit should Close wrong network modal , setLayer , setEnabledAccout, setWalletAddress and addTooken when initialized === L1 or L2', async () => {
+    useSelectorMock.mockReturnValueOnce(false)
+
+    const initialState = {
+      ...mockedInitialState,
+      setup: {
+        ...mockedInitialState.setup,
+        baseEnabled: true,
+        accountEnabled: true,
+        userTriggeredChainSwitch: true,
+        netLayer: LAYER.L1,
+      },
+    }
+
+    jest
+      .spyOn(networkService, 'initializeAccount')
+      .mockResolvedValueOnce(LAYER.L1)
+
+    const store = mockStore(initialState)
+    const wrapper = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    await act(async () => {
+      renderHook(() => useWalletConnect(), {
+        wrapper,
+      })
+    })
+
+    const actions: AnyAction[] = store.getActions()
+    expect(actions).toHaveLength(5)
+    const expectedActions = [
+      { payload: 'wrongNetworkModal', type: 'UI/MODAL/CLOSE' },
+      { payload: 'L1', type: 'SETUP/LAYER/SET' },
+      { payload: true, type: 'SETUP/ACCOUNT/SET' },
+      { payload: undefined, type: 'SETUP/WALLETADDRESS/SET' },
+      { type: 'TOKENLIST/GET/REQUEST' },
+    ]
+    expect(actions).toEqual(expectedActions)
+  })
+
+  test('triggerInit should return false when intialized is not defined', async () => {
+    useSelectorMock.mockReturnValueOnce(false)
+
+    const initialState = {
+      ...mockedInitialState,
+      setup: {
+        ...mockedInitialState.setup,
+        baseEnabled: true,
+        accountEnabled: true,
+        userTriggeredChainSwitch: true,
+        netLayer: LAYER.L1,
+      },
+    }
+
+    jest
+      .spyOn(networkService, 'initializeAccount')
+      .mockResolvedValueOnce('other')
+
+    const store = mockStore(initialState)
+    const wrapper = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    await act(async () => {
+      renderHook(() => useWalletConnect(), {
+        wrapper,
+      })
+    })
+
+    const actions: AnyAction[] = store.getActions()
+    expect(actions).toHaveLength(0)
+  })
+
+  test('connectBOBARequest should tigger doConnectToLayer(L2), reset chain Connection and open walletSelectorModal when provider is not defined', async () => {
+    const initialState = {
+      ...mockedInitialState,
+      setup: {
+        ...mockedInitialState.setup,
+        baseEnabled: true,
+        accountEnabled: true,
+        connectBOBA: true,
+      },
+    }
+
+    const store = mockStore(initialState)
+    const wrapper = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    await act(async () => {
+      renderHook(() => useWalletConnect(), {
+        wrapper,
+      })
+    })
+
+    const actions: AnyAction[] = store.getActions()
+    expect(actions).toHaveLength(3)
+    const expectedActions = [
+      { payload: false, type: 'SETUP/CONNECT' },
+      { payload: false, type: 'SETUP/CONNECT_ETH' },
+      { payload: 'walletSelectorModal', type: 'UI/MODAL/OPEN' },
+    ]
+    expect(actions).toEqual(expectedActions)
+  })
+
+  test('connectETHRequest should tigger doConnectToLayer(L1), reset chain Connection and open walletSelectorModal', async () => {
+    const initialState = {
+      ...mockedInitialState,
+      setup: {
+        ...mockedInitialState.setup,
+        baseEnabled: true,
+        accountEnabled: true,
+        connectETH: true,
+      },
+    }
+    const store = mockStore(initialState)
+    const wrapper = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+
+    await act(async () => {
+      renderHook(() => useWalletConnect(), {
+        wrapper,
+      })
+    })
+
+    const actions: AnyAction[] = store.getActions()
+    expect(actions).toHaveLength(3)
+    const expectedActions = [
+      { payload: false, type: 'SETUP/CONNECT' },
+      { payload: false, type: 'SETUP/CONNECT_ETH' },
+      { payload: 'walletSelectorModal', type: 'UI/MODAL/OPEN' },
+    ]
+    expect(actions).toEqual(expectedActions)
+  })
+})

--- a/src/hooks/useWalletConnect/index.ts
+++ b/src/hooks/useWalletConnect/index.ts
@@ -114,6 +114,7 @@ export const useWalletConnect = () => {
             }
           }
         } catch (err) {
+          console.log('reset connection chain')
           resetConnectChain()
         }
       }
@@ -132,6 +133,8 @@ export const useWalletConnect = () => {
   // listening for l1 connection request
   useEffect(() => {
     if (connectETHRequest) {
+      console.log('insideConnectEthRequest')
+
       doConnectToLayer('L1')
     }
   }, [connectETHRequest, doConnectToLayer])
@@ -139,12 +142,15 @@ export const useWalletConnect = () => {
   // listening for l2 connection request
   useEffect(() => {
     if (connectBOBARequest) {
+      console.log('inside connect boba request')
       doConnectToLayer('L2')
     }
   }, [connectBOBARequest, doConnectToLayer])
 
   useEffect(() => {
     if (connectRequest && !networkService.walletService.provider) {
+      console.log('DISABLE_WALLETCONNECT', DISABLE_WALLETCONNECT)
+      console.log('inside connectRequest')
       // bypass walletSelectorModal
       if (DISABLE_WALLETCONNECT) {
         triggerInit()
@@ -154,5 +160,5 @@ export const useWalletConnect = () => {
     }
   }, [dispatch, connectRequest, triggerInit])
 
-  return { triggerInit }
+  return { triggerInit, doConnectToLayer }
 }

--- a/src/hooks/useWalletConnect/index.ts
+++ b/src/hooks/useWalletConnect/index.ts
@@ -133,8 +133,6 @@ export const useWalletConnect = () => {
   // listening for l1 connection request
   useEffect(() => {
     if (connectETHRequest) {
-      console.log('insideConnectEthRequest')
-
       doConnectToLayer('L1')
     }
   }, [connectETHRequest, doConnectToLayer])
@@ -142,15 +140,12 @@ export const useWalletConnect = () => {
   // listening for l2 connection request
   useEffect(() => {
     if (connectBOBARequest) {
-      console.log('inside connect boba request')
       doConnectToLayer('L2')
     }
   }, [connectBOBARequest, doConnectToLayer])
 
   useEffect(() => {
     if (connectRequest && !networkService.walletService.provider) {
-      console.log('DISABLE_WALLETCONNECT', DISABLE_WALLETCONNECT)
-      console.log('inside connectRequest')
       // bypass walletSelectorModal
       if (DISABLE_WALLETCONNECT) {
         triggerInit()

--- a/src/util/tests/index.ts
+++ b/src/util/tests/index.ts
@@ -71,3 +71,7 @@ export const mockLocalStorage = (() => {
     },
   }
 })()
+
+export type EnvType = string | number | null | undefined
+
+export const DISABLE_WALLETCONNECT: EnvType = 'true'

--- a/src/util/tests/index.ts
+++ b/src/util/tests/index.ts
@@ -71,7 +71,3 @@ export const mockLocalStorage = (() => {
     },
   }
 })()
-
-export type EnvType = string | number | null | undefined
-
-export const DISABLE_WALLETCONNECT: EnvType = 'true'


### PR DESCRIPTION
## Testing

![image](https://github.com/bobanetwork/gateway/assets/81116391/c6867ec0-130d-494e-87f9-33dbf23731ad)


- Layer L1/L2 should triggerInit if accountEnable is false and baseEnabled is true
- Layer L1/L2 should triggerInit if accountEnable is true and baseEnabled is true but chain has been changed
- triggerInit should Open No Metamask Modal when intialized === nometamask
- triggerInit should Open Wrong Network Modal when intialized === wrongnetwork
- triggerInit should Set account enabled False when intialized === false
- triggerInit should Close wrong network modal , setLayer , setEnabledAccout, setWalletAddress and addTooken when initialized === L1 or L2
- triggerInit should return false when intialized is not defined
- connectBOBARequest should tigger doConnectToLayer(L2), reset chain Connection and open walletSelectorModal when provider is not defined
- connectETHRequest should tigger doConnectToLayer(L1), reset chain Connection and open walletSelectorModal