### PR TITLE
Fix: Arb/OP watcher 

### DIFF
--- a/src/services/transaction.service.ts
+++ b/src/services/transaction.service.ts
@@ -56,6 +56,9 @@ class TransactionService {
     networkConfig = networkService.networkConfig
   ): Promise<any[]> {
     let L2Txs = []
+    if (!networkConfig || !networkConfig['OMGX_WATCHER_URL']) {
+      return L2Txs
+    }
     try {
       const responseL2 = await omgxWatcherAxiosInstance(networkConfig)
         .post('get.l2.transactions', {
@@ -117,6 +120,9 @@ class TransactionService {
   // fetch L1 pending transactions from omgxWatcherAxiosInstance
   async fetchL1PendingTx(networkConfig = networkService.networkConfig) {
     let txL1pending = []
+    if (!networkConfig || !networkConfig['OMGX_WATCHER_URL']) {
+      return txL1pending
+    }
     try {
       const responseL1pending = await omgxWatcherAxiosInstance(
         networkConfig

--- a/src/util/network/config/arbitrum.ts
+++ b/src/util/network/config/arbitrum.ts
@@ -2,9 +2,6 @@ import { NetworkDetail } from './network-details.types'
 
 export const arbitrumConfig: NetworkDetail = {
   Testnet: {
-    OMGX_WATCHER_URL: `https://api-watcher.goerli.boba.network/`,
-    VERIFIER_WATCHER_URL: `https://api-verifier.goerli.boba.network/`,
-    META_TRANSACTION: `https://api-meta-transaction.goerli.boba.network/`,
     addressManager: `0x6FF9c8FF8F0B6a0763a3030540c21aFC721A9148`,
     MM_Label: `Goerli`,
     L1: {
@@ -33,9 +30,6 @@ export const arbitrumConfig: NetworkDetail = {
     },
   },
   Mainnet: {
-    OMGX_WATCHER_URL: `https://api-watcher.mainnet.boba.network/`,
-    VERIFIER_WATCHER_URL: `https://api-verifier.mainnet.boba.network/`,
-    META_TRANSACTION: `https://api-meta-transaction.mainnet.boba.network/`,
     addressManager: `0x8376ac6C3f73a25Dd994E0b0669ca7ee0C02F089`,
     MM_Label: `Mainnet`,
     L1: {

--- a/src/util/network/config/network-details.types.ts
+++ b/src/util/network/config/network-details.types.ts
@@ -8,9 +8,9 @@ export type TxPayload = {
 }
 
 export type NetworkDetailChainConfig = {
-  OMGX_WATCHER_URL: string
+  OMGX_WATCHER_URL?: string
   VERIFIER_WATCHER_URL?: string
-  META_TRANSACTION: string
+  META_TRANSACTION?: string
   MM_Label: string
   addressManager: string
   L1: {

--- a/src/util/network/config/optimism.ts
+++ b/src/util/network/config/optimism.ts
@@ -2,9 +2,6 @@ import { NetworkDetail } from './network-details.types'
 
 export const optimismConfig: NetworkDetail = {
   Testnet: {
-    OMGX_WATCHER_URL: `https://api-watcher.goerli.boba.network/`,
-    VERIFIER_WATCHER_URL: `https://api-verifier.goerli.boba.network/`,
-    META_TRANSACTION: `https://api-meta-transaction.goerli.boba.network/`,
     MM_Label: `optimismTestnet`,
     addressManager: `0x6FF9c8FF8F0B6a0763a3030540c21aFC721A9148`,
     L1: {
@@ -33,9 +30,6 @@ export const optimismConfig: NetworkDetail = {
     },
   },
   Mainnet: {
-    OMGX_WATCHER_URL: `https://api-watcher.mainnet.boba.network/`,
-    VERIFIER_WATCHER_URL: `https://api-verifier.mainnet.boba.network/`,
-    META_TRANSACTION: `https://api-meta-transaction.mainnet.boba.network/`,
     addressManager: `0x8376ac6C3f73a25Dd994E0b0669ca7ee0C02F089`,
     MM_Label: `optimismMainnet`,
     L1: {


### PR DESCRIPTION
Based on migrate/graphql branch since history had several bugs that were already fixed in the prev PR. 

## Overview

Fixes 1 minor bug.

## Changes

- OmgWatcher for OP/ARB removed & made it optional in general, since not all networks may have it.

## Testing

Local testing.
