### PR TITLE
Adding unit tests to thrid party bridges

### DIFF
--- a/src/services/data.service.test.ts
+++ b/src/services/data.service.test.ts
@@ -1,0 +1,25 @@
+import axios from 'axios'
+import { loadThirdPartyBridges } from './data.service'
+import { THIRD_PARTY_BRIDGES_LIST } from 'util/constant'
+
+jest.mock('axios')
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+describe('loadThirdPartyBridges', () => {
+  it('Fetch Should return third Load party bridges', async () => {
+    const data = THIRD_PARTY_BRIDGES_LIST
+
+    mockedAxios.get.mockResolvedValue({ data })
+
+    await expect(loadThirdPartyBridges()).resolves.toEqual(data)
+  })
+
+  it('Fetch error catch error', async () => {
+    const errorMessage = 'An error occurred'
+    const error = new Error(errorMessage)
+
+    mockedAxios.get.mockRejectedValue(error)
+
+    await expect(loadThirdPartyBridges()).rejects.toThrow(errorMessage)
+  })
+})

--- a/src/services/data.service.ts
+++ b/src/services/data.service.ts
@@ -6,6 +6,6 @@ export const loadThirdPartyBridges = async () => {
     const response = await axios.get(THIRD_PARTY_BRIDGES_LIST)
     return response.data
   } catch (error) {
-    return error
+    throw error
   }
 }


### PR DESCRIPTION
![image](https://github.com/bobanetwork/gateway/assets/81116391/80ee8d5f-7df7-43dd-b589-0298cf19dedb)


1. Fetch Should return third Load party bridges
2. Fetch error catch error