### PR TITLE
fix: Fixes history page #382

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "http-browserify": "^1.7.0",
     "https-browserify": "^1.0.0",
     "human-standard-token-abi": "^2.0.0",
+    "lodash.uniqwith": "^4.5.0",
     "lodash.flatten": "^4.4.0",
     "lodash.intersection": "^4.4.0",
     "lodash.isequal": "^4.5.0",

--- a/src/util/lodash.ts
+++ b/src/util/lodash.ts
@@ -3,5 +3,6 @@ import intersection from 'lodash.intersection'
 import orderBy from 'lodash.orderby'
 import keyBy from 'lodash.keyby'
 import flatten from 'lodash.flatten'
+import uniqWith from 'lodash.uniqwith'
 
-export { isEqual, intersection, orderBy, keyBy, flatten }
+export { isEqual, intersection, orderBy, keyBy, flatten, uniqWith }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13355,6 +13355,11 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
+lodash.uniqwith@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz#7a0cbf65f43b5928625a9d4d0dc54b18cadc7ef3"
+  integrity sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q==
+
 lodash.upperfirst@4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"


### PR DESCRIPTION
# Overview

- Filter for uniqueness in transactions for history page

## Why
This is needed due to our tightly coupled network logic and the introduction of the Optimism/Arbitrum network on the Gateway. 

Example for Goerli, which exists for 3 chainConfigs: 
- Goerli <> Optimism
- Goerli <> Arbitrum
- Goerli <> Boba Eth

And for that reason transactions re-occur 3 times. 