### PR TITLE
fix: network switch, token select

### DIFF
--- a/src/components/NetworkSelector/index.tsx
+++ b/src/components/NetworkSelector/index.tsx
@@ -58,7 +58,10 @@ export const NetworkSelector = () => {
 
   useEffect(() => {
     if (networkChainIds) {
-      const chainId = Number(networkChainIds[layer])
+      const chainId =
+        typeof networkChainIds === 'object'
+          ? Number(networkChainIds[layer])
+          : networkChainIds
       setCurrentOption({
         label: CHAIN_ID_LIST[chainId].siteName,
         value: String(chainId),

--- a/src/components/bridge/NetworkPickerList/index.tsx
+++ b/src/components/bridge/NetworkPickerList/index.tsx
@@ -73,9 +73,6 @@ export const NetworkList: FC<NetworkListProps> = ({
         setTeleportationDestChainId(chainDetail.chainId[layer?.toUpperCase()])
       )
     } else {
-      if (chainDetail.chain === Network.ETHEREUM_SEPOLIA) {
-        dispatch(setBridgeType(BRIDGE_TYPE.CLASSIC))
-      }
       dispatch(
         setNetwork({
           network: chainDetail.chain,

--- a/src/containers/Bridging/BridgeTypeSelector/index.tsx
+++ b/src/containers/Bridging/BridgeTypeSelector/index.tsx
@@ -63,14 +63,6 @@ const BridgeTypeSelector = () => {
     dispatch(setBridgeType(BRIDGE_TYPE.CLASSIC))
   }, [activeNetworkType])
 
-  // @todo return <></> for the testnet with sepolia connection.
-  // as sepolia doesn't support the fast / light bridge
-  // note: remove conditional check once light bridge deployed to sepolia.
-
-  if (!!isAnchorageEnabled) {
-    return <></>
-  }
-
   return (
     <BridgeTabs>
       <BridgeTabItem

--- a/src/containers/Bridging/chain/constant.ts
+++ b/src/containers/Bridging/chain/constant.ts
@@ -16,6 +16,11 @@ type IconType = {
 type NetworkIconsType = Record<string, IconType>
 
 export const NETWORK_ICONS: NetworkIconsType = {
+  // reset back to ethereum once goerli is gone
+  ethereum_sepolia: {
+    L1: EthereumIcon,
+    L2: BobaIcon,
+  },
   ethereum: {
     L1: EthereumIcon,
     L2: BobaIcon,


### PR DESCRIPTION
# Changes

1. Resolved crash page for chain switch
2. Reenabled light bridge sepolia
3. Reenabled bridge selector for sepolia
4. BNB Testnet is active, bridging loader works on my end, so is the asset not supported