### PR TITLE
fix: add more details to unstake window

### DIFF
--- a/src/components/stake/transactionList/index.tsx
+++ b/src/components/stake/transactionList/index.tsx
@@ -82,7 +82,7 @@ const TransactionList = ({ stakeInfo }: TransactionListInterface) => {
             Next unstake window:{' '}
           </ModalTypography>
           <Typography variant="body2">
-            {` ${dayjs(unlocktimeNextBegin).format('DD')}-${dayjs(
+            {` ${dayjs(unlocktimeNextBegin).format('DD MMM')} - ${dayjs(
               unlocktimeNextEnd
             ).format('DD MMM YYYY hh:mm A')}`}
           </Typography>


### PR DESCRIPTION
:clipboard:  closes: 

## Overview

Adds more details to unstake window for date ranges that span across months

## Tasks

- [x] No debug console statement added 
- [x] Should use only typescript.
- [] Does have unit test for each touched file with 90% coverage
- [] Does have an integration test if any UI changes.


## Changes

updated to display DD MMM for the beginning range

## Testing


## UI Snaps

![image](https://github.com/bobanetwork/gateway/assets/26090752/14173a9f-30c3-4397-8308-f1678a11e250)



