### PR TITLE
feat: Add token mapping/support for disburser check lightbridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@apollo/client": "^3.5.10",
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@bobanetwork/graphql-utils": "^1.1.9",
-    "@bobanetwork/light-bridge-chains": "^1.0.9",
+    "@bobanetwork/light-bridge-chains": "^1.1.0",
     "@bobanetwork/register": "^0.0.25",
     "@bobanetwork/sdk": "1.0.7",
     "@cfx-kit/wallet-avatar": "^0.0.5",

--- a/src/actions/networkAction.ts
+++ b/src/actions/networkAction.ts
@@ -51,9 +51,9 @@ export const isTeleportationOfAssetSupported = (
     networkService.isTeleportationOfAssetSupported(layer, asset, destChainId)
   )
 
-export const getDisburserBalance = (layer: string, asset: string) =>
+export const getDisburserBalance = (sourceChainId: string, destChainId: string, asset: string) =>
   createAction('DEPOSIT/TELEPORTATION/DISBURSER_BALANCE', () =>
-    networkService.getNativeDisburserBalance(layer, asset)
+    networkService.getDisburserBalance(sourceChainId, destChainId, asset)
   )
 
 export const depositWithLightBridge = (

--- a/src/containers/modals/tokenPicker/TokenPickerModal.tsx
+++ b/src/containers/modals/tokenPicker/TokenPickerModal.tsx
@@ -148,8 +148,10 @@ const TokenPickerModal: FC<TokenPickerModalProps> = ({ open, tokenIndex }) => {
       const isSupported = await dispatch(
         isTeleportationOfAssetSupported(layer, token.address, destChainId)
       )
+      const sourceChainId = NetworkList[activeNetworkType].find((n) => n.chain === activeNetwork)
+        .chainId[layer]
       const disburserBalance = await dispatch(
-        getDisburserBalance(layer, token.address)
+        getDisburserBalance(sourceChainId, destChainId, token.address)
       )
       dispatch(setTeleportationOfAssetSupported(isSupported))
       dispatch(setTeleportationDisburserBalance(disburserBalance))

--- a/src/hooks/useBridgeAlerts/index.ts
+++ b/src/hooks/useBridgeAlerts/index.ts
@@ -71,9 +71,9 @@ const useBridgeAlerts = () => {
   const activeNetwork = useSelector(selectActiveNetwork())
   const tokenForTeleportationSupported: ITeleportationTokenSupport =
     useSelector(selectIsTeleportationOfAssetSupported())
-  const disburserBalance: BigNumber | undefined = useSelector(
+  const disburserBalance: string | undefined = useSelector(
     selectTeleportationDisburserBalance()
-  )
+  )?.toString()
 
   const { isActiveNetworkBnb } = useNetworkInfo()
   // fast input layer 1
@@ -127,7 +127,8 @@ const useBridgeAlerts = () => {
           })
         )
 
-        if (disburserBalance && disburserBalance.lt(amountToBridge)) {
+        console.log("DISBBBBBBBB", disburserBalance, amountToBridge, disburserBalance !== undefined && BigNumber.from(disburserBalance).lt(amountToBridge))
+        if (disburserBalance !== undefined && BigNumber.from(disburserBalance).lt(amountToBridge)) {
           dispatch(
             setBridgeAlert({
               meta: ALERT_KEYS.TELEPORTATION_DISBURSER_OUT_OF_FUNDS,

--- a/src/services/abi/Teleportation.abi.ts
+++ b/src/services/abi/Teleportation.abi.ts
@@ -1,5 +1,6 @@
 export const TeleportationABI = [
   'function initialize()',
+  'function disburser() view returns (address)',
   'function owner() view returns (address)',
   'function supportedTokens(address, uint32) view returns (bool supported, uint256 minDepositAmount, uint256 maxDepositAmount, uint256 maxTransferAmountPerDay, uint256 transferredAmount, uint256 transferTimestampCheckPoint)',
   'function teleportAsset(address _token, uint256 _amount, uint32 _toChainId) payable',

--- a/src/services/networkService.ts
+++ b/src/services/networkService.ts
@@ -80,6 +80,7 @@ import {
   TxPayload,
 } from '../util/network/config/network-details.types'
 import { LiquidityPoolLayer } from 'types/earn.types'
+import { getDestinationTokenAddress } from '@bobanetwork/light-bridge-chains'
 
 const ERROR_ADDRESS = '0x0000000000000000000000000000000000000000'
 const L2GasOracle = '0x420000000000000000000000000000000000000F'
@@ -2147,22 +2148,27 @@ class NetworkService {
     return this.LightBridge!.attach(lightBridgeAddr).connect(provider)
   }
 
-  async getNativeDisburserBalance(destChainId, token) {
+  async getDisburserBalance(sourceChainId, destChainId, token) {
     // not just simply L2/L1 as also L2<>L2 supported, ..
     const destProvider = new ethers.providers.StaticJsonRpcProvider(
       getRpcUrlByChainId(destChainId)
     )
+    const destTokenAddr = getDestinationTokenAddress(token, sourceChainId, destChainId)
     const isNative =
-      token === ethers.constants.AddressZero ||
-      token === this.addresses.L2_ETH_Address
+      destTokenAddr === ethers.constants.AddressZero ||
+      destTokenAddr === this.addresses.L2_ETH_Address
 
     const disburserAddr =
       await this.getLightBridgeContract(destChainId)?.disburser()
-    if (!disburserAddr || !isNative) {
+    if (!disburserAddr) {
       return
     }
-    // TODO: Add token support later on (proper token mapping, avoid code duplication & maintenance overhead)
-    return destProvider.getBalance(disburserAddr)
+    if (isNative) {
+      return destProvider.getBalance(disburserAddr)
+    } else {
+      const destToken = this.L1_TEST_Contract!.attach(destTokenAddr).connect(destProvider)
+      return destToken.balanceOf(disburserAddr)
+    }
   }
 
   async isTeleportationOfAssetSupported(layer, token, destChainId) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1278,10 +1278,10 @@
     node-fetch "^2.6.1"
     ts-jest "^29.1.2"
 
-"@bobanetwork/light-bridge-chains@^1.0.9":
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/@bobanetwork/light-bridge-chains/-/light-bridge-chains-1.0.12.tgz#1ce53fe1f0d9294104b948ff43bc6adfb7f1a4e9"
-  integrity sha512-HKQ1be6hYp7FrZhas1ntrEvIuJjqWGT6YxfFxzDX/F4VyUzrCXp+++G8PSfp1VbAk3apQSfS5ndlpEx9/DJD8Q==
+"@bobanetwork/light-bridge-chains@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@bobanetwork/light-bridge-chains/-/light-bridge-chains-1.1.0.tgz#511b860bc25a5cea6b7c112503e15322cd47577f"
+  integrity sha512-YQ/WNTT2g11q8KLSHd+9IGvIYA8XJGhZtmQqilftOWeOkPzhd1rYU8xEe9PCOCqRIzBfZGqVTwUoDyl+lQlA0A==
   dependencies:
     dotenv "^8.6.0"
     ethers "^5.5.4"


### PR DESCRIPTION
Gateway now also checks for the token on the destination network (this also eliminates the issue when bridging from Boba BNB to BNB as BOBA is the native asset on L2): 

![image](https://github.com/bobanetwork/gateway/assets/28724551/36ac4a0b-1d3e-4b08-850b-4966d5a04f2e)

Please ignore the other errors and the balance 0 etc. (manipulated it in the DOM to not have to bridge boba tokens to test)