### PR TITLE
feat: Add exit fee for Lightbridge

### DIFF
--- a/src/hooks/useAmountToReceive/index.ts
+++ b/src/hooks/useAmountToReceive/index.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import {
   selectAmountToBridge,
-  selectBridgeType,
+  selectBridgeType, selectDestChainIdTeleportation,
   selectL1FeeRateN,
   selectL2FeeRateN,
   selectLayer,
@@ -12,6 +12,7 @@ import { toWei_String } from 'util/amountConvert'
 import { formatTokenAmount } from 'util/common'
 import { LAYER } from 'util/constant'
 import { BRIDGE_TYPE } from 'containers/Bridging/BridgeTypeSelector'
+import { CHAIN_ID_LIST } from '../../util/network/network.util'
 
 /**
  * This hook is used for getting receivable amount.
@@ -26,8 +27,10 @@ export const useAmountToReceive = () => {
   const amount = useSelector(selectAmountToBridge())
   const token = useSelector(selectTokenToBridge())
   const layer = useSelector(selectLayer())
+  const lightBridgeDestChainId = useSelector(selectDestChainIdTeleportation()) // can be L2 <> L2, we don't want a exit fee here
   const l2FeeRateN = useSelector(selectL2FeeRateN)
   const l1FeeRateN = useSelector(selectL1FeeRateN)
+  const l1LightBridgeFeeRateN = '1' // static, as only set in backend for now for light bridge when exiting to L1
 
   const [amountToReceive, setAmountToReceive] = useState<
     string | null | number
@@ -56,10 +59,16 @@ export const useAmountToReceive = () => {
         setAmountToReceive(amount)
       }
     } else {
+
+      const isLightBridgeExitToL1 = (!lightBridgeDestChainId && layer === LAYER.L2) || CHAIN_ID_LIST[lightBridgeDestChainId]?.layer === LAYER.L1
       if (bridgeType === BRIDGE_TYPE.CLASSIC) {
         setAmountToReceive(formatedAmount())
       } else if (bridgeType === BRIDGE_TYPE.FAST) {
         const value = Number(amount) * ((100 - Number(l1FeeRateN)) / 100)
+        setAmountToReceive(value.toFixed(3))
+      } else if (bridgeType === BRIDGE_TYPE.LIGHT && isLightBridgeExitToL1) {
+        // lightbridge exit fee to L1 only
+        const value = Number(amount) * ((100 - Number(l1LightBridgeFeeRateN)) / 100)
         setAmountToReceive(value.toFixed(3))
       } else {
         // Teleportation, no fees as of now


### PR DESCRIPTION
# Lightbridge exit fee
Setting to 1% statically. 

Note: Not yet live on backend - but I think nobody would complain if they receive more than shown on the gateway. 

So I think we are fine with merging this, otherwise let's wait until the backend change is live. 