### PR TITLE
fix: Add decimal to add precision for lb exit fee

### DIFF
--- a/src/hooks/useAmountToReceive/index.ts
+++ b/src/hooks/useAmountToReceive/index.ts
@@ -69,7 +69,7 @@ export const useAmountToReceive = () => {
       } else if (bridgeType === BRIDGE_TYPE.LIGHT && isLightBridgeExitToL1) {
         // lightbridge exit fee to L1 only
         const value = Number(amount) * ((100 - Number(l1LightBridgeFeeRateN)) / 100)
-        setAmountToReceive(value.toFixed(3))
+        setAmountToReceive(value.toFixed(4))
       } else {
         // Teleportation, no fees as of now
         setAmountToReceive(amount)

--- a/src/hooks/useBridgeAlerts/index.ts
+++ b/src/hooks/useBridgeAlerts/index.ts
@@ -33,7 +33,7 @@ import { LAYER } from 'util/constant'
 import BN from 'bignumber.js'
 import { BRIDGE_TYPE } from 'containers/Bridging/BridgeTypeSelector'
 import { Network } from 'util/network/network.util'
-import { BigNumber, BigNumberish, ethers } from 'ethers'
+import { BigNumber, BigNumberish, ethers, utils } from 'ethers'
 import { formatEther } from '@ethersproject/units'
 import { useNetworkInfo } from 'hooks/useNetworkInfo'
 
@@ -193,7 +193,7 @@ const useBridgeAlerts = () => {
             setBridgeAlert({
               meta: ALERT_KEYS.MAX_BRIDGE_AMOUNT_PER_DAY_EXCEEDED,
               type: 'error',
-              text: `Your chosen amount exceeds the daily limit. Maximum remaining amount for this asset is: ${allowedAmount}`,
+              text: `Your chosen amount exceeds the daily limit. Maximum remaining amount for this asset is: ${utils.formatEther(allowedAmount)}`,
             })
           )
         }


### PR DESCRIPTION
Small amounts cause rounding on the UI which then wrongfully doesn't reflect the exit fee. 

- Also fixes the formatting issue @boyuan-chen mentioned here: https://github.com/bobanetwork/gateway/pull/498#issuecomment-2076123195
![image](https://github.com/bobanetwork/gateway/assets/28724551/baf18932-f8fe-4a01-bc58-3f33ba7f4d17)
