### PR TITLE
Withdrawal Message Copy update for different state.

### DIFF
--- a/src/containers/modals/MultiStepWithdrawalModal/config.ts
+++ b/src/containers/modals/MultiStepWithdrawalModal/config.ts
@@ -21,7 +21,7 @@ export const steps = [
   { label: 'Wait about 7 days', passiveStep: true },
   {
     label: 'Claim Withdrawal',
-    description: `Claim your funds. This is the final step.`,
+    description: `The proof has been submitted. Please wait 7 days to claim your withdrawal`,
     passiveStep: false,
     btnLbl: 'Claim Withdrawal',
   },

--- a/src/reducers/setupReducer.ts
+++ b/src/reducers/setupReducer.ts
@@ -89,6 +89,7 @@ const setupReducer = (state: ISetupReducerState = initialState, action) => {
         connectBOBA: action.payload,
       }
     case 'SETUP/CONNECT':
+      console.log(`trigger connect!`)
       return {
         ...state,
         connect: action.payload,


### PR DESCRIPTION
:clipboard:  closes: 

changes
---
- Check and update proof message rather than timeout and update.
- Updated the claim withdrawal message before passing 7 day and after.


### On checking for proof withdrawal.
![Screenshot 2024-05-10 at 4 32 06 AM](https://github.com/bobanetwork/gateway/assets/86316370/618877a4-6478-442c-9aab-4797e4b80b30)

### Before claim button enable
![Screenshot 2024-05-10 at 4 27 22 AM](https://github.com/bobanetwork/gateway/assets/86316370/6b535ee9-594e-41ee-82d4-e23fa4a82ae3)

### After claim button enable
![Screenshot 2024-05-10 at 4 27 36 AM](https://github.com/bobanetwork/gateway/assets/86316370/693bb2da-23f7-4354-9251-4c011f2244ad)

