### PR TITLE
reverted the timestamp check

### DIFF
--- a/src/containers/modals/MultiStepWithdrawalModal/index.tsx
+++ b/src/containers/modals/MultiStepWithdrawalModal/index.tsx
@@ -60,9 +60,10 @@ export const MultiStepWithdrawalModal: FC<Props> = ({ open, isNewTx }) => {
       // Since the contract previously emitted the event with LEGACY_ERC20_TOKEN,
       // we now need to utilize the following logic to accurately retrieve ETH token data for
       // all transactions made before the contract update.
-      // NOTE: `0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000` it's id belong to WETH so in future
-      // the logic needs to be change by adding check for timestamp or blocknumber incase if it's getting supported on L2.
-      if (withdrawalToken === '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000') {
+      if (
+        withdrawalToken === '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000' &&
+        Number(withdrawalConfig.timeStamp) < 1714546800
+      ) {
         withdrawalToken = '0x4200000000000000000000000000000000000006'
       }
       const token =


### PR DESCRIPTION
:clipboard:  closes: 

Reverted the timestamp check code back for WETH tokenId in case of classic bridge withdrawal.