### PR TITLE
Fix : Sepolia withdrawal with dispute game factroy contract!

### DIFF
--- a/src/actions/bridgeAction.ts
+++ b/src/actions/bridgeAction.ts
@@ -129,7 +129,7 @@ export const handleProveWithdrawal = (payload) =>
   })
 export const handleProveWithdrawalWithFraudProof = (payload) =>
   createAction('PROVE_WITHDRAWAL/CREATE', () => {
-    return bridgeService.prooveTransactionWithdrawalWithFraudProof(payload)
+    return bridgeService.proveTransactionWithdrawalWithFraudProof(payload)
   })
 
 export const claimWithdrawal = (payload) =>

--- a/src/actions/bridgeAction.ts
+++ b/src/actions/bridgeAction.ts
@@ -127,6 +127,10 @@ export const handleProveWithdrawal = (payload) =>
   createAction('PROVE_WITHDRAWAL/CREATE', () => {
     return bridgeService.prooveTransactionWithdrawal(payload)
   })
+export const handleProveWithdrawalWithFraudProof = (payload) =>
+  createAction('PROVE_WITHDRAWAL/CREATE', () => {
+    return bridgeService.prooveTransactionWithdrawalWithFraudProof(payload)
+  })
 
 export const claimWithdrawal = (payload) =>
   createAction('CLAIM_WITHDRAWAL/CREATE', () => {

--- a/src/containers/modals/MultiStepWithdrawalModal/VerticalStepper.tsx
+++ b/src/containers/modals/MultiStepWithdrawalModal/VerticalStepper.tsx
@@ -28,6 +28,7 @@ export const VerticalStepper = (props: IVerticalStepperProps) => {
     loading,
     isButtonDisabled,
     withdrawalConfig,
+    doesFruadProofWithdrawalEnable,
   } = useAnchorageWithdrawal(props)
 
   const prepareDesc = (desc?: string, step?: string) => {
@@ -37,7 +38,9 @@ export const VerticalStepper = (props: IVerticalStepperProps) => {
 
     if (activeStep === 3 && step === 'Prove Withdrawal') {
       if (!canProoveTx) {
-        return `${desc} The current L2 block submitted is ${latestBlockNumber}, and your block is ${txBlockNumber}. This will take about 3 days 12 hrs.`
+        return `${desc} The current L2 block submitted is ${latestBlockNumber}, and your block is ${txBlockNumber}. ${!doesFruadProofWithdrawalEnable ? '' : 'This will take about 3 days 12 hrs.'}`
+      } else {
+        return `Your transaction has reached L1. You can now proove your withdrawal`
       }
     }
 

--- a/src/containers/modals/MultiStepWithdrawalModal/VerticalStepper.tsx
+++ b/src/containers/modals/MultiStepWithdrawalModal/VerticalStepper.tsx
@@ -26,6 +26,7 @@ import {
   SecondaryActionButton,
   StepContainer,
 } from './index.styles'
+import oracleService from 'services/oracle/oracle.service'
 
 interface IVerticalStepperProps {
   handleClose: () => void
@@ -64,18 +65,14 @@ export const VerticalStepper = (props: IVerticalStepperProps) => {
           setTxBlock(withdrawalConfig?.blockNumber)
           // TODO: cleanup with moving to service.
           let latestBlockOnL1 =
-            await networkService?.L2OutputOracle?.latestBlockNumber()
+            await oracleService.getLatestL2OutputBlockNumber()
           setLatestBlock(latestBlockOnL1)
 
           while (
             isMounted &&
             Number(latestBlockOnL1) < Number(withdrawalConfig?.blockNumber)
           ) {
-            // @todo: check why block number is not getting updated.
-            // Update the latest block number
-            // TODO: cleanup with moving to service.
-            latestBlockOnL1 =
-              await networkService?.L2OutputOracle?.latestBlockNumber()
+            latestBlockOnL1 = await oracleService.getLatestL2OutputBlockNumber()
             setLatestBlock(latestBlockOnL1)
             // Wait for 12 seconds before checking again
             await new Promise((resolve) => setTimeout(resolve, 12000))

--- a/src/containers/modals/MultiStepWithdrawalModal/config.ts
+++ b/src/containers/modals/MultiStepWithdrawalModal/config.ts
@@ -13,8 +13,7 @@ export const steps = [
   },
   {
     label: 'Prove Withdrawal',
-    description:
-      'You will be able to submit your proof once your transaction is submitted to L1.',
+    description: 'You can submit your proof once your transaction reaches L1.',
     passiveStep: false,
     btnLbl: 'Prove Withdrawal',
   },

--- a/src/hooks/useAnchorageWithdrawal/index.ts
+++ b/src/hooks/useAnchorageWithdrawal/index.ts
@@ -1,0 +1,223 @@
+import {
+  anchorageGraphQLService,
+  IHandleProveWithdrawalConfig,
+} from '@bobanetwork/graphql-utils'
+import {
+  claimWithdrawal,
+  handleProveWithdrawal,
+  withdrawErc20TokenAnchorage,
+  withdrawNativeTokenAnchorage,
+} from 'actions/bridgeAction'
+import { setConnectETH } from 'actions/setupAction'
+import { closeModal, openError, openModal } from 'actions/uiAction'
+import { utils } from 'ethers'
+import { useNetworkInfo } from 'hooks/useNetworkInfo'
+import { useEffect, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { selectLayer } from 'selectors'
+import networkService from 'services/networkService'
+import oracleService from 'services/oracle/oracle.service'
+import { addDaysToDate, dayNowUnix, isBeforeDate } from 'util/dates'
+
+const useAnchorageWithdrawal = (props) => {
+  const dispatch = useDispatch<any>()
+  const layer = useSelector(selectLayer())
+  const [withdrawalConfig, setWithdrawalConfig] =
+    useState<IHandleProveWithdrawalConfig>()
+  const [latestLogs, setLatestLogs] = useState<null | []>(null)
+  const [activeStep, setActiveStep] = useState(0)
+  const [loading, setLoading] = useState(false)
+  const [canProoveTx, setCanProoveTx] = useState(false)
+  const [latestBlockNumber, setLatestBlockNumber] = useState(0)
+  const [txBlockNumber, setTxBlockNumber] = useState(0)
+  const { isActiveNetworkBnbTestnet } = useNetworkInfo()
+
+  useEffect(() => {
+    if (props.reenterWithdrawConfig) {
+      dispatch(setConnectETH(true))
+      setWithdrawalConfig(props.reenterWithdrawConfig)
+      setActiveStep(props.reenterWithdrawConfig.step)
+    }
+  }, [layer])
+
+  const handleNext = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep + 1)
+  }
+
+  const switchLayerToL1 = () => {
+    dispatch(setConnectETH(true))
+  }
+
+  const isButtonDisabled = () => {
+    if (activeStep === 3) {
+      return !canProoveTx
+    } else if (activeStep === 5) {
+      // can claim only if tx proove 7 day before
+      const txWith7Day = addDaysToDate(withdrawalConfig?.timeStamp, 7)
+      return !Number(props.amountToBridge) || !isBeforeDate(txWith7Day)
+    }
+
+    return !Number(props.amountToBridge)
+  }
+
+  useEffect(() => {
+    let isMounted = true // Flag to track component mount state
+    const validateBlockNumberAndEnableProov = async () => {
+      if (activeStep === 3 && withdrawalConfig?.blockNumber) {
+        try {
+          setTxBlockNumber(withdrawalConfig?.blockNumber)
+          let latestBlockOnL1 =
+            await oracleService.getLatestL2OutputBlockNumber()
+          setLatestBlockNumber(latestBlockOnL1)
+
+          while (
+            isMounted &&
+            Number(latestBlockOnL1) < Number(withdrawalConfig?.blockNumber)
+          ) {
+            latestBlockOnL1 = await oracleService.getLatestL2OutputBlockNumber()
+            setLatestBlockNumber(latestBlockOnL1)
+            // Wait for 12 seconds before checking again
+            await new Promise((resolve) => setTimeout(resolve, 12000))
+          }
+
+          if (isMounted) {
+            setCanProoveTx(true)
+          }
+        } catch (error) {
+          console.log(`Error while checking blocknumber`, error)
+        }
+      }
+    }
+    if (withdrawalConfig && activeStep === 3) {
+      validateBlockNumberAndEnableProov()
+    }
+
+    return () => {
+      isMounted = false // Update mount state on unmount
+    }
+  }, [activeStep])
+
+  const initWithdrawalStep = async () => {
+    setLoading(true)
+    const isNativeWithdrawal =
+      props.token.address === networkService.addresses.NETWORK_NATIVE_TOKEN
+
+    const amount = utils
+      .parseUnits(
+        props.amountToBridge!.toString(),
+        props.token ? props.token.decimals : null
+      )
+      .toString()
+
+    let receipt
+    if (isNativeWithdrawal) {
+      receipt = await dispatch(
+        withdrawNativeTokenAnchorage({
+          amount,
+          isActiveNetworkBnb: isActiveNetworkBnbTestnet,
+        })
+      )
+    } else {
+      receipt = await dispatch(
+        withdrawErc20TokenAnchorage({ amount, token: props.token.address })
+      )
+    }
+
+    if (receipt.hasOwnProperty('message')) {
+      props.handleClose()
+      dispatch(openError(receipt.message))
+    } else if (receipt) {
+      setActiveStep(2)
+      setWithdrawalConfig({ blockNumber: receipt })
+      setLoading(false)
+    } else {
+      setLoading(false)
+      props.handleClose()
+    }
+  }
+
+  const proofWithdrawalStep = async () => {
+    setLoading(true)
+    console.log([`sending tx for proove withdrawal`, withdrawalConfig])
+    const res = await dispatch(
+      handleProveWithdrawal({ txInfo: withdrawalConfig })
+    )
+    if (res) {
+      setActiveStep(5)
+      setLatestLogs(res)
+      setWithdrawalConfig({
+        blockNumber: res[0].blockNumber,
+        timeStamp: dayNowUnix(),
+      })
+      setLoading(false)
+    } else {
+      dispatch(openError(`The withdrawal verification failed!`))
+      setLoading(false)
+      props.handleClose()
+    }
+  }
+
+  const claimWithdrawalStep = async () => {
+    if (!!withdrawalConfig) {
+      setLoading(true)
+      let logs: any[] = latestLogs || []
+      if (!logs || !logs?.length) {
+        const resLogs =
+          await anchorageGraphQLService.findWithdrawalMessagedPassed(
+            withdrawalConfig?.withdrawalHash || '',
+            networkService.networkConfig?.L2.chainId || ''
+          )
+
+        logs = resLogs.filter(
+          (log) => log?.withdrawalHash === withdrawalConfig?.withdrawalHash
+        )
+      }
+      const res = await dispatch(claimWithdrawal({ logs }))
+      if (res) {
+        dispatch(closeModal('bridgeMultiStepWithdrawal'))
+        dispatch(
+          openModal({
+            modal: 'transactionSuccess',
+            isAnchorageWithdrawal: true,
+          })
+        )
+        setLoading(false)
+      } else {
+        console.log(`error state!`, res)
+        // TODO: handled failed state
+      }
+    }
+  }
+
+  const handleWithdrawalAction = () => {
+    switch (activeStep) {
+      case 0:
+        initWithdrawalStep()
+        break
+      case 2:
+        switchLayerToL1()
+        break
+      case 3:
+        proofWithdrawalStep()
+        break
+      case 5:
+        claimWithdrawalStep()
+        break
+    }
+    handleNext()
+  }
+
+  return {
+    handleWithdrawalAction,
+    latestBlockNumber,
+    withdrawalConfig,
+    isButtonDisabled,
+    txBlockNumber,
+    canProoveTx,
+    activeStep,
+    loading,
+    layer,
+  }
+}
+
+export default useAnchorageWithdrawal

--- a/src/hooks/useAnchorageWithdrawal/index.ts
+++ b/src/hooks/useAnchorageWithdrawal/index.ts
@@ -219,9 +219,7 @@ const useAnchorageWithdrawal = (props) => {
           (log) => log?.withdrawalHash === withdrawalConfig?.withdrawalHash
         )
       }
-      const res = await dispatch(
-        claimWithdrawal({ logs, doesFruadProofWithdrawalEnable })
-      )
+      const res = await dispatch(claimWithdrawal({ logs }))
       if (res) {
         dispatch(closeModal('bridgeMultiStepWithdrawal'))
         dispatch(

--- a/src/hooks/useAnchorageWithdrawal/index.ts
+++ b/src/hooks/useAnchorageWithdrawal/index.ts
@@ -58,7 +58,7 @@ const useAnchorageWithdrawal = (props) => {
       return !canProoveTx
     } else if (activeStep === 5) {
       if (doesFruadProofWithdrawalEnable) {
-        return canFinalizedTx
+        return !canFinalizedTx
       } else {
         // can claim only if tx proove 7 day before
         const txWith7Day = addDaysToDate(withdrawalConfig?.timeStamp, 7)
@@ -114,7 +114,6 @@ const useAnchorageWithdrawal = (props) => {
           transactionHash: withdrawalConfig?.withdrawalHash,
         })
 
-        console.log(`check withdrawal status`, res)
         if (res) {
           setCanFinalizedTx(true)
         } else {
@@ -260,6 +259,7 @@ const useAnchorageWithdrawal = (props) => {
     latestBlockNumber,
     withdrawalConfig,
     isButtonDisabled,
+    canFinalizedTx,
     txBlockNumber,
     canProoveTx,
     activeStep,

--- a/src/hooks/useAnchorageWithdrawal/index.ts
+++ b/src/hooks/useAnchorageWithdrawal/index.ts
@@ -181,7 +181,6 @@ const useAnchorageWithdrawal = (props) => {
 
   const proofWithdrawalStep = async () => {
     setLoading(true)
-    console.log([`sending tx for proove withdrawal`, withdrawalConfig])
     let res
     if (doesFruadProofWithdrawalEnable) {
       res = await dispatch(
@@ -220,7 +219,9 @@ const useAnchorageWithdrawal = (props) => {
           (log) => log?.withdrawalHash === withdrawalConfig?.withdrawalHash
         )
       }
-      const res = await dispatch(claimWithdrawal({ logs }))
+      const res = await dispatch(
+        claimWithdrawal({ logs, doesFruadProofWithdrawalEnable })
+      )
       if (res) {
         dispatch(closeModal('bridgeMultiStepWithdrawal'))
         dispatch(

--- a/src/hooks/useAppConfig/index.ts
+++ b/src/hooks/useAppConfig/index.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+import { useSelector } from 'react-redux'
+import { selectActiveNetwork, selectActiveNetworkType } from 'selectors'
+import { Network, NetworkType } from 'util/network/network.util'
+
+const useAppConfig = () => {
+  const [doesFruadProofWithdrawalEnable, setDoesFruadProofWithdrawalEnable] =
+    useState<boolean>(false)
+
+  const network = useSelector(selectActiveNetwork())
+  const networkType = useSelector(selectActiveNetworkType())
+
+  useEffect(() => {
+    if (network === Network.ETHEREUM && networkType === NetworkType.TESTNET) {
+      setDoesFruadProofWithdrawalEnable(true)
+    } else {
+      setDoesFruadProofWithdrawalEnable(false)
+    }
+  }, [network, networkType])
+
+  return {
+    doesFruadProofWithdrawalEnable,
+  }
+}
+
+export default useAppConfig

--- a/src/services/abi/OptimismPortal2.abi.ts
+++ b/src/services/abi/OptimismPortal2.abi.ts
@@ -1,0 +1,810 @@
+export const OptimismPortal2ABI = [
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_proofMaturityDelaySeconds',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_disputeGameFinalityDelaySeconds',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    inputs: [],
+    name: 'BadTarget',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'CallPaused',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ContentLengthMismatch',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'EmptyItem',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'GasEstimation',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidDataRemainder',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidHeader',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'LargeCalldata',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'OutOfGas',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'SmallGasLimit',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'Unauthorized',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'UnexpectedList',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'UnexpectedString',
+    type: 'error',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'contract IDisputeGame',
+        name: 'disputeGame',
+        type: 'address',
+      },
+    ],
+    name: 'DisputeGameBlacklisted',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint8',
+        name: 'version',
+        type: 'uint8',
+      },
+    ],
+    name: 'Initialized',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'GameType',
+        name: 'newGameType',
+        type: 'uint32',
+      },
+      {
+        indexed: true,
+        internalType: 'Timestamp',
+        name: 'updatedAt',
+        type: 'uint64',
+      },
+    ],
+    name: 'RespectedGameTypeSet',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'version',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: 'opaqueData',
+        type: 'bytes',
+      },
+    ],
+    name: 'TransactionDeposited',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'withdrawalHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: false,
+        internalType: 'bool',
+        name: 'success',
+        type: 'bool',
+      },
+    ],
+    name: 'WithdrawalFinalized',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'withdrawalHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+    ],
+    name: 'WithdrawalProven',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'withdrawalHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'proofSubmitter',
+        type: 'address',
+      },
+    ],
+    name: 'WithdrawalProvenExtension1',
+    type: 'event',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract IDisputeGame',
+        name: '_disputeGame',
+        type: 'address',
+      },
+    ],
+    name: 'blacklistDisputeGame',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_withdrawalHash',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'address',
+        name: '_proofSubmitter',
+        type: 'address',
+      },
+    ],
+    name: 'checkWithdrawal',
+    outputs: [],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_value',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint64',
+        name: '_gasLimit',
+        type: 'uint64',
+      },
+      {
+        internalType: 'bool',
+        name: '_isCreation',
+        type: 'bool',
+      },
+      {
+        internalType: 'bytes',
+        name: '_data',
+        type: 'bytes',
+      },
+    ],
+    name: 'depositTransaction',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract IDisputeGame',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'disputeGameBlacklist',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'disputeGameFactory',
+    outputs: [
+      {
+        internalType: 'contract DisputeGameFactory',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'disputeGameFinalityDelaySeconds',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'donateETH',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'uint256',
+            name: 'nonce',
+            type: 'uint256',
+          },
+          {
+            internalType: 'address',
+            name: 'sender',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'target',
+            type: 'address',
+          },
+          {
+            internalType: 'uint256',
+            name: 'value',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'gasLimit',
+            type: 'uint256',
+          },
+          {
+            internalType: 'bytes',
+            name: 'data',
+            type: 'bytes',
+          },
+        ],
+        internalType: 'struct Types.WithdrawalTransaction',
+        name: '_tx',
+        type: 'tuple',
+      },
+    ],
+    name: 'finalizeWithdrawalTransaction',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'uint256',
+            name: 'nonce',
+            type: 'uint256',
+          },
+          {
+            internalType: 'address',
+            name: 'sender',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'target',
+            type: 'address',
+          },
+          {
+            internalType: 'uint256',
+            name: 'value',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'gasLimit',
+            type: 'uint256',
+          },
+          {
+            internalType: 'bytes',
+            name: 'data',
+            type: 'bytes',
+          },
+        ],
+        internalType: 'struct Types.WithdrawalTransaction',
+        name: '_tx',
+        type: 'tuple',
+      },
+      {
+        internalType: 'address',
+        name: '_proofSubmitter',
+        type: 'address',
+      },
+    ],
+    name: 'finalizeWithdrawalTransactionExternalProof',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    name: 'finalizedWithdrawals',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'guardian',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract DisputeGameFactory',
+        name: '_disputeGameFactory',
+        type: 'address',
+      },
+      {
+        internalType: 'contract SystemConfig',
+        name: '_systemConfig',
+        type: 'address',
+      },
+      {
+        internalType: 'contract SuperchainConfig',
+        name: '_superchainConfig',
+        type: 'address',
+      },
+      {
+        internalType: 'GameType',
+        name: '_initialRespectedGameType',
+        type: 'uint32',
+      },
+    ],
+    name: 'initialize',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'l2Sender',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint64',
+        name: '_byteCount',
+        type: 'uint64',
+      },
+    ],
+    name: 'minimumGasLimit',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '_withdrawalHash',
+        type: 'bytes32',
+      },
+    ],
+    name: 'numProofSubmitters',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'params',
+    outputs: [
+      {
+        internalType: 'uint128',
+        name: 'prevBaseFee',
+        type: 'uint128',
+      },
+      {
+        internalType: 'uint64',
+        name: 'prevBoughtGas',
+        type: 'uint64',
+      },
+      {
+        internalType: 'uint64',
+        name: 'prevBlockNum',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'paused',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'proofMaturityDelaySeconds',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'proofSubmitters',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'uint256',
+            name: 'nonce',
+            type: 'uint256',
+          },
+          {
+            internalType: 'address',
+            name: 'sender',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'target',
+            type: 'address',
+          },
+          {
+            internalType: 'uint256',
+            name: 'value',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint256',
+            name: 'gasLimit',
+            type: 'uint256',
+          },
+          {
+            internalType: 'bytes',
+            name: 'data',
+            type: 'bytes',
+          },
+        ],
+        internalType: 'struct Types.WithdrawalTransaction',
+        name: '_tx',
+        type: 'tuple',
+      },
+      {
+        internalType: 'uint256',
+        name: '_disputeGameIndex',
+        type: 'uint256',
+      },
+      {
+        components: [
+          {
+            internalType: 'bytes32',
+            name: 'version',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'stateRoot',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'messagePasserStorageRoot',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'latestBlockhash',
+            type: 'bytes32',
+          },
+        ],
+        internalType: 'struct Types.OutputRootProof',
+        name: '_outputRootProof',
+        type: 'tuple',
+      },
+      {
+        internalType: 'bytes[]',
+        name: '_withdrawalProof',
+        type: 'bytes[]',
+      },
+    ],
+    name: 'proveWithdrawalTransaction',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'provenWithdrawals',
+    outputs: [
+      {
+        internalType: 'contract IDisputeGame',
+        name: 'disputeGameProxy',
+        type: 'address',
+      },
+      {
+        internalType: 'uint64',
+        name: 'timestamp',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'respectedGameType',
+    outputs: [
+      {
+        internalType: 'GameType',
+        name: '',
+        type: 'uint32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'respectedGameTypeUpdatedAt',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'GameType',
+        name: '_gameType',
+        type: 'uint32',
+      },
+    ],
+    name: 'setRespectedGameType',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'superchainConfig',
+    outputs: [
+      {
+        internalType: 'contract SuperchainConfig',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'systemConfig',
+    outputs: [
+      {
+        internalType: 'contract SystemConfig',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'version',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    stateMutability: 'payable',
+    type: 'receive',
+  },
+]

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -31,11 +31,6 @@ export const L2GasOracle = '0x420000000000000000000000000000000000000F'
 export const L2ToL1MessagePasserAddress =
   '0x4200000000000000000000000000000000000016'
 
-// NOTE: contract only for sepolia 11155111 chain
-// make sure to move this to registery and import
-export const OptimismPortal2Address =
-  '0x3e3a5D73f5044EFD0676468f221DeA9C4975c549'
-
 const ADDRESS_CONFIG = {
   [NetworkType.MAINNET]: {
     [Network.ETHEREUM]: {

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -31,6 +31,11 @@ export const L2GasOracle = '0x420000000000000000000000000000000000000F'
 export const L2ToL1MessagePasserAddress =
   '0x4200000000000000000000000000000000000016'
 
+// NOTE: contract only for sepolia 11155111 chain
+// make sure to move this to registery and import
+export const OptimismPortal2Address =
+  '0x3e3a5D73f5044EFD0676468f221DeA9C4975c549'
+
 const ADDRESS_CONFIG = {
   [NetworkType.MAINNET]: {
     [Network.ETHEREUM]: {

--- a/src/services/bridge/bridge.services.ts
+++ b/src/services/bridge/bridge.services.ts
@@ -1,3 +1,4 @@
+import { anchorageGraphQLService } from '@bobanetwork/graphql-utils'
 import { BigNumber, constants, Contract, utils } from 'ethers'
 import { formatEther } from 'ethers/lib/utils'
 import {
@@ -9,7 +10,11 @@ import {
   L2ToL1MessagePasserABI,
   OptimismPortalABI,
 } from 'services/abi'
-import { L2ToL1MessagePasserAddress } from 'services/app.service'
+import { OptimismPortal2ABI } from 'services/abi/OptimismPortal2.abi'
+import {
+  L2ToL1MessagePasserAddress,
+  OptimismPortal2Address,
+} from 'services/app.service'
 import networkService from 'services/networkService'
 import { ERROR_CODE } from 'util/constant'
 
@@ -477,6 +482,159 @@ export class BridgeService {
     }
   }
 
+  async prooveTransactionWithdrawalWithFraudProof({ txInfo }) {
+    try {
+      const L2ToL1MessagePasserContract = new Contract(
+        L2ToL1MessagePasserAddress,
+        L2ToL1MessagePasserABI,
+        networkService.L2Provider
+      )
+
+      let logs: Array<any> = await L2ToL1MessagePasserContract.queryFilter(
+        L2ToL1MessagePasserContract.filters.MessagePassed(),
+        txInfo.blockNumber,
+        txInfo.blockNumber
+      )
+      console.log(`logs`, logs)
+
+      if (txInfo.withdrawalHash) {
+        logs = logs.filter(
+          (b) => b!.args.withdrawalHash === txInfo.withdrawalHash
+        )
+      }
+
+      console.log(`filter logs`, txInfo, logs)
+
+      if (!logs || logs.length === 0 || !logs[0]) {
+        throw new Error(`${ERROR_CODE} No L2ToL1MessagePasser logs`)
+      }
+
+      const types = [
+        'uint256',
+        'address',
+        'address',
+        'uint256',
+        'uint256',
+        'bytes',
+      ]
+
+      const encoded = utils.defaultAbiCoder.encode(types, [
+        logs[0].args.nonce,
+        logs[0].args.sender,
+        logs[0].args.target,
+        logs[0].args.value,
+        logs[0].args.gasLimit,
+        logs[0].args.data,
+      ])
+
+      const slot = utils.keccak256(encoded)
+
+      const withdrawalHash = logs[0].args.withdrawalHash
+
+      if (withdrawalHash !== slot) {
+        throw new Error(`Withdrawal hash does not match`)
+      }
+
+      const messageSlot = utils.keccak256(
+        utils.defaultAbiCoder.encode(
+          ['bytes32', 'uint256'],
+          [slot, constants.HashZero]
+        )
+      )
+
+      // LOOPING TO CHECK THE LATEST BLOCK NUMBER.
+      let latestBlockOnL1 =
+        await anchorageGraphQLService.getLatestFDGSubmittedBlock(
+          networkService.chainId!
+        )
+
+      console.log(`latestBlockOnL1`, latestBlockOnL1)
+      while (Number(latestBlockOnL1) < Number(txInfo.blockNumber)) {
+        await new Promise((resolve) => setTimeout(resolve, 12000))
+        latestBlockOnL1 =
+          await anchorageGraphQLService.getLatestFDGSubmittedBlock(
+            networkService.chainId!
+          )
+      }
+
+      // make use of anchorageService
+      const disputeGameSubmissionPayload =
+        await anchorageGraphQLService.getRootClaimOfFDGSubmission(
+          networkService.chainId!,
+          txInfo.blockNumber
+        )
+      console.log(`disputeGameSubmissionPayload`, disputeGameSubmissionPayload)
+      const disputeGameIndex = disputeGameSubmissionPayload.index
+      const proposalBlockNumber = disputeGameSubmissionPayload.l2BlockNumber
+      const proposalBlock = await networkService.L2Provider!.send(
+        'eth_getBlockByNumber',
+        [Number(proposalBlockNumber), false]
+      )
+
+      console.log('requesting proof', proposalBlock, messageSlot)
+      const proof = await networkService.L2Provider!.send('eth_getProof', [
+        L2ToL1MessagePasserAddress,
+        [messageSlot],
+        proposalBlock.number, // reading hex block number.
+      ])
+
+      console.log('Generated proof', proof)
+      const signer = networkService.provider!.getSigner()
+
+      const optimismPortal2Contract = new Contract(
+        OptimismPortal2Address,
+        OptimismPortal2ABI,
+        signer
+      )
+
+      console.log(`params`, {
+        tuple: [
+          logs[0].args.nonce,
+          logs[0].args.sender,
+          logs[0].args.target,
+          logs[0].args.value,
+          logs[0].args.gasLimit,
+          logs[0].args.data,
+        ],
+        disputeGameIndex,
+        rootProof: [
+          constants.HashZero,
+          proposalBlock.stateRoot,
+          proof.storageHash,
+          proposalBlock.hash,
+        ],
+        proof: proof.storageProof[0].proof,
+      })
+
+      // TODO: validate the prove withdrawal transaction.
+      const proveTx = await optimismPortal2Contract.proveWithdrawalTransaction(
+        [
+          logs[0].args.nonce,
+          logs[0].args.sender,
+          logs[0].args.target,
+          logs[0].args.value,
+          logs[0].args.gasLimit,
+          logs[0].args.data,
+        ],
+        disputeGameIndex,
+        [
+          constants.HashZero,
+          proposalBlock.stateRoot,
+          proof.storageHash,
+          proposalBlock.hash,
+        ],
+        proof.storageProof[0].proof
+      )
+      // console.log(`needed gas`, gas)
+      const txReceipt = await proveTx.wait()
+      console.log(`txReceipt`, txReceipt)
+      return logs
+    } catch (error) {
+      console.log(`Err: proveWithdrwal`, error)
+      return error
+    }
+  }
+
   // can be usable to show the value of gas on UI
   async estimateGasFinalWithdrawal({ logs }) {
     try {
@@ -507,6 +665,39 @@ export class BridgeService {
     } catch (error) {
       console.log(`Err estimateGasFinalWithdrawal`, error)
       return error
+    }
+  }
+
+  async doesWithdrawalCanFinalized({
+    transactionHash,
+  }: {
+    transactionHash?: string
+  }) {
+    try {
+      if (!transactionHash) {
+        return false
+      }
+
+      console.log(`params`, {
+        transactionHash,
+        account: networkService.account,
+      })
+
+      const optimismConract = new Contract(
+        OptimismPortal2Address, //TODO: optimism portal address.
+        OptimismPortal2ABI,
+        networkService.L1Provider
+      )
+
+      const response = await optimismConract.checkWithdrawal(
+        transactionHash,
+        networkService.account
+      )
+
+      console.log(`response`, response)
+      return response
+    } catch (error) {
+      console.log(`ERR: doesWithdrawalCanFinalized`, error)
     }
   }
 

--- a/src/services/bridge/bridge.services.ts
+++ b/src/services/bridge/bridge.services.ts
@@ -701,7 +701,13 @@ export class BridgeService {
     }
   }
 
-  async finalizeTransactionWithdrawal({ logs }: { logs: any[] }) {
+  async finalizeTransactionWithdrawal({
+    logs,
+    doesFruadProofWithdrawalEnable,
+  }: {
+    logs: any[]
+    doesFruadProofWithdrawalEnable: boolean
+  }) {
     try {
       if (!logs.length || !logs[0]) {
         throw new Error(`${ERROR_CODE} invalid logs passed!`)
@@ -712,11 +718,22 @@ export class BridgeService {
 
       const signer = networkService.provider!.getSigner()
 
-      const optimismPortalContract = new Contract(
-        networkService.addresses.OptimismPortalProxy,
-        OptimismPortalABI,
-        signer
-      )
+      let optimismPortalContract
+
+      if (doesFruadProofWithdrawalEnable) {
+        // in case of fruad proof based withdrawal.
+        optimismPortalContract = new Contract(
+          OptimismPortal2Address,
+          OptimismPortal2ABI,
+          signer
+        )
+      } else {
+        optimismPortalContract = new Contract(
+          networkService.addresses.OptimismPortalProxy,
+          OptimismPortalABI,
+          signer
+        )
+      }
 
       const finalSubmitTx =
         await optimismPortalContract.finalizeWithdrawalTransaction([

--- a/src/services/bridge/bridge.services.ts
+++ b/src/services/bridge/bridge.services.ts
@@ -673,7 +673,7 @@ export class BridgeService {
       return response
     } catch (error) {
       console.log(`ERR: doesWithdrawalCanFinalized`, error)
-      return error
+      return false
     }
   }
 

--- a/src/services/bridge/bridge.services.ts
+++ b/src/services/bridge/bridge.services.ts
@@ -495,15 +495,12 @@ export class BridgeService {
         txInfo.blockNumber,
         txInfo.blockNumber
       )
-      console.log(`logs`, logs)
 
       if (txInfo.withdrawalHash) {
         logs = logs.filter(
           (b) => b!.args.withdrawalHash === txInfo.withdrawalHash
         )
       }
-
-      console.log(`filter logs`, txInfo, logs)
 
       if (!logs || logs.length === 0 || !logs[0]) {
         throw new Error(`${ERROR_CODE} No L2ToL1MessagePasser logs`)
@@ -548,7 +545,6 @@ export class BridgeService {
           networkService.chainId!
         )
 
-      console.log(`latestBlockOnL1`, latestBlockOnL1)
       while (Number(latestBlockOnL1) < Number(txInfo.blockNumber)) {
         await new Promise((resolve) => setTimeout(resolve, 12000))
         latestBlockOnL1 =
@@ -563,7 +559,7 @@ export class BridgeService {
           networkService.chainId!,
           txInfo.blockNumber
         )
-      console.log(`disputeGameSubmissionPayload`, disputeGameSubmissionPayload)
+
       const disputeGameIndex = disputeGameSubmissionPayload.index
       const proposalBlockNumber = disputeGameSubmissionPayload.l2BlockNumber
       const proposalBlock = await networkService.L2Provider!.send(
@@ -571,14 +567,12 @@ export class BridgeService {
         [Number(proposalBlockNumber), false]
       )
 
-      console.log('requesting proof', proposalBlock, messageSlot)
       const proof = await networkService.L2Provider!.send('eth_getProof', [
         L2ToL1MessagePasserAddress,
         [messageSlot],
         proposalBlock.number, // reading hex block number.
       ])
 
-      console.log('Generated proof', proof)
       const signer = networkService.provider!.getSigner()
 
       const optimismPortal2Contract = new Contract(
@@ -678,11 +672,6 @@ export class BridgeService {
         return false
       }
 
-      console.log(`params`, {
-        transactionHash,
-        account: networkService.account,
-      })
-
       const optimismConract = new Contract(
         OptimismPortal2Address, //TODO: optimism portal address.
         OptimismPortal2ABI,
@@ -698,6 +687,7 @@ export class BridgeService {
       return response
     } catch (error) {
       console.log(`ERR: doesWithdrawalCanFinalized`, error)
+      return error
     }
   }
 

--- a/src/services/oracle/oracle.service.test.ts
+++ b/src/services/oracle/oracle.service.test.ts
@@ -251,4 +251,42 @@ describe('OracleService', () => {
       expect(result).toBe(error)
     })
   })
+
+  describe('getLatestL2OutputBlockNumber >', () => {
+    let l2OutputOracleContractMockMock: any
+    let getSignerMock: any
+    let latestBlockNumberMock: any
+
+    beforeEach(() => {
+      // jest.spyOn(console, 'log').mockImplementation(() => { })
+      getSignerMock = jest.fn().mockReturnValue({})
+      latestBlockNumberMock = jest.fn().mockReturnValue(12345)
+      ;(providers.JsonRpcProvider as unknown as jest.Mock).mockReturnValue({
+        getSigner: getSignerMock,
+      })
+      ;(networkService as any).L1Provider = new providers.JsonRpcProvider(
+        'http://demo.local'
+      )
+
+      l2OutputOracleContractMockMock = {
+        latestBlockNumber: latestBlockNumberMock,
+      }
+      ;(Contract as unknown as jest.Mock).mockReturnValue(
+        l2OutputOracleContractMockMock
+      )
+      jest.spyOn(oracleService, 'getBobaFeeChoice').mockResolvedValue(undefined)
+    })
+
+    it('Should throw error and return ZERO in case contract address in not found', async () => {
+      networkService.addresses.L2OutputOracleProxy = undefined
+      const result = await oracleService.getLatestL2OutputBlockNumber()
+      expect(result).toBe(0)
+    })
+
+    it('Should return correct block', async () => {
+      networkService.addresses.L2OutputOracleProxy = '0xL2OutputOracleProxy'
+      const result = await oracleService.getLatestL2OutputBlockNumber()
+      expect(result).toBe(12345)
+    })
+  })
 })

--- a/src/services/oracle/oracle.service.ts
+++ b/src/services/oracle/oracle.service.ts
@@ -1,7 +1,7 @@
 import { TransactionResponse } from '@ethersproject/providers'
 import { addBobaFee } from 'actions/setupAction'
 import { Contract } from 'ethers'
-import { BobaGasPriceOracleABI } from 'services/abi'
+import { BobaGasPriceOracleABI, L2OutputOracleABI } from 'services/abi'
 import networkService from 'services/networkService'
 import { ERROR_CODE } from 'util/constant'
 import { Network } from 'util/network/network.util'
@@ -83,6 +83,27 @@ class OracleService {
     } catch (error) {
       console.log(`OS: switchFeeToken error`, error)
       return error
+    }
+  }
+
+  async getLatestL2OutputBlockNumber() {
+    try {
+      if (!networkService.addresses.L2OutputOracleProxy) {
+        throw new Error(`${ERROR_CODE} L2OutputOracleProxy invalid address!`)
+      }
+
+      const l2OutputOracleContract = new Contract(
+        networkService.addresses.L2OutputOracleProxy,
+        L2OutputOracleABI,
+        networkService.L1Provider
+      )
+
+      const blockNumber = await l2OutputOracleContract.latestBlockNumber()
+
+      return blockNumber
+    } catch (error) {
+      console.log(`ERR: Latest oracle block number`, error)
+      return 0
     }
   }
 }

--- a/src/util/dates.ts
+++ b/src/util/dates.ts
@@ -50,10 +50,48 @@ export const addDaysToDate = (timestamp, day) => {
 export const diffBetweenTimeStamp = (time1: number, time2: number) => {
   const date1 = dayjs.unix(time1)
   const date2 = dayjs.unix(time2)
-
   return date1.diff(date2, 'seconds')
 }
 
 export const dayNowUnix = () => {
   return dayjs().unix()
+}
+
+export const formatDuration = (seconds) => {
+  const totalMinutes = Math.floor(seconds / 60)
+  const totalHours = Math.floor(totalMinutes / 60)
+  const days = Math.floor(totalHours / 24)
+  const hours = totalHours % 24
+  const minutes = totalMinutes % 60
+
+  let result = ''
+
+  if (days > 0) {
+    result += `${days}day${days > 1 ? 's' : ''} `
+  }
+  if (hours > 0) {
+    result += `${hours}hr `
+  }
+  if (minutes > 0) {
+    result += `${minutes}min `
+  }
+
+  return result.trim()
+}
+
+export const formatDurationInDaysHrs = (seconds) => {
+  const totalDays = seconds / (60 * 60 * 24)
+  const days = Math.floor(totalDays)
+  const hours = Math.round((totalDays - days) * 24)
+  let result = ''
+
+  if (days > 0) {
+    result += `${days} day${days > 1 ? 's' : ''}`
+  }
+  if (hours > 0 || days === 0) {
+    // Always show hours if there are no days
+    result += ` ${hours} hr${hours > 1 ? 's' : ''}`
+  }
+
+  return result.trim()
 }

--- a/src/util/network/config/ethereum.ts
+++ b/src/util/network/config/ethereum.ts
@@ -23,7 +23,7 @@ export const ethereumConfig: NetworkDetail = {
       tokenName: 'ETH',
     },
     L2: {
-      name: 'BOBA Sepolia L2',
+      name: 'Boba Sepolia',
       chainId: 28882,
       chainIdHex: '0x70d2',
       rpcUrl: [`https://sepolia.boba.network`],
@@ -67,7 +67,7 @@ export const ethereumConfig: NetworkDetail = {
       tokenName: 'ETH',
     },
     L2: {
-      name: 'BOBA L2',
+      name: 'Boba Network',
       chainId: 288,
       chainIdHex: '0x120',
       rpcUrl: [


### PR DESCRIPTION
Changes:
---

- change: latest L2output block fetching to oracle service.
- change: useAnchorageWithdrawal as separate hook
- change to remove the MM add network warning!
- Fetch block number from diputeGameFactory contract 
- update copy incase of fruad proof withdrawal enable 
- useAppConfig hook to handled app related configuration!.
- provetransaction withdrawal for fruad proof service function with action to trigger. 
- checkWithdrawal with op_portal2 contract 
- withdrawal finalize status call from services to enable button. 
- hardcoded address for sepolia op portal2 with note.


NOTE: _flow is yet to test as it's failing with error `can not estimate gas`_