### PR TITLE
Chore/loading boba balance cleanup stake

### DIFF
--- a/src/actions/fixedAction.ts
+++ b/src/actions/fixedAction.ts
@@ -28,8 +28,11 @@ export const withdrawFS_Savings = (stakeID: number) =>
     fixedSavingService.withdrawSavings(stakeID)
   )
 
-export const getFS_Saves = () =>
+export const fetchSavings = () =>
   createAction('GET/FS_SAVES', () => fixedSavingService.loadSavings())
 
-export const getFS_Info = () =>
+export const fetchStakeInfo = () =>
   createAction('GET/FS_INFO', () => fixedSavingService.loadAccountSaveInfo())
+
+export const fetchBobaTokenDetail = () =>
+  createAction('BOBA_BALANCE/GET', () => fixedSavingService.loadBobaBalance())

--- a/src/reducers/balanceReducer.ts
+++ b/src/reducers/balanceReducer.ts
@@ -37,8 +37,6 @@ const balanceReducer = (state: IBalanceReducerState = initialState, action) => {
   switch (action.type) {
     case 'BALANCE/GET/SUCCESS':
       const { layer1, layer2 } = action.payload
-      console.log(`layer2`, layer2)
-      console.log(`layer1`, layer1)
       return {
         ...state,
         layer1,

--- a/src/reducers/balanceReducer.ts
+++ b/src/reducers/balanceReducer.ts
@@ -37,6 +37,8 @@ const balanceReducer = (state: IBalanceReducerState = initialState, action) => {
   switch (action.type) {
     case 'BALANCE/GET/SUCCESS':
       const { layer1, layer2 } = action.payload
+      console.log(`layer2`, layer2)
+      console.log(`layer1`, layer1)
       return {
         ...state,
         layer1,

--- a/src/reducers/fixedReducer.ts
+++ b/src/reducers/fixedReducer.ts
@@ -16,11 +16,13 @@ limitations under the License. */
 interface IFixedReducerState {
   stakeCount: number
   stakeInfo: any
+  bobaToken: any
 }
 
 const initialState: IFixedReducerState = {
   stakeCount: 0,
   stakeInfo: {},
+  bobaToken: null,
 }
 
 const fixedReducer = (state: IFixedReducerState = initialState, action) => {
@@ -29,6 +31,11 @@ const fixedReducer = (state: IFixedReducerState = initialState, action) => {
       return { ...state, ...action.payload }
     case 'GET/FS_INFO/SUCCESS':
       return { ...state, ...action.payload }
+    case 'BOBA_BALANCE/GET/SUCCESS':
+      return {
+        ...state,
+        bobaToken: action.payload,
+      }
     default:
       return state
   }

--- a/src/services/fixedsaving/fixedSaving.service.ts
+++ b/src/services/fixedsaving/fixedSaving.service.ts
@@ -178,6 +178,23 @@ class FixedSavingService {
       return error
     }
   }
+
+  async loadBobaBalance() {
+    try {
+      if (!networkService.account) {
+        throw new Error(`${ERROR_CODE} wallet not connected!`)
+      }
+      const bobaContract = this.loadBobaTokenContract()
+      const balance = await bobaContract.balanceOf(networkService.account)
+      const decimals = await bobaContract.decimals()
+      return {
+        balance,
+        decimals,
+      }
+    } catch (error) {
+      return error
+    }
+  }
 }
 
 const fixedSavingService = new FixedSavingService()


### PR DESCRIPTION
Change:
- loading boba token details instead of fetching whole tokens and balances.
- fetching savings and stake info post deposit.
- cleanup repetative call for info and stake and balances.
- updated content and prepare redux state / reducer / action / selector accordgingly.
- added function for loading boba balance.