### PR TITLE
Fix/disable onramp if key not present

### DIFF
--- a/src/containers/Bridging/BridgeAction/__snapshots__/index.test.tsx.snap
+++ b/src/containers/Bridging/BridgeAction/__snapshots__/index.test.tsx.snap
@@ -45,20 +45,6 @@ exports[`BridgeAction AccountEnabled is true should match snapshot 1`] = `
           Bridge
         </h3>
       </button>
-      <button
-        class="sc-gsFSXq copFJf sc-ikkxIA"
-        data-testid="connect-btn"
-        label="[object Object]"
-        style="width: 100%;"
-        type="button"
-      >
-         
-        <h3
-          class="sc-jlZhew bOWxgm"
-        >
-          Buy with Ramp Network
-        </h3>
-      </button>
     </div>
   </div>
 </DocumentFragment>

--- a/src/containers/Bridging/BridgeAction/index.tsx
+++ b/src/containers/Bridging/BridgeAction/index.tsx
@@ -11,7 +11,7 @@ import {
   selectTokenToBridge,
 } from 'selectors'
 import { BridgeActionButton, BridgeActionContainer } from '../styles'
-import { PURCHASE_RAMP_URL } from 'util/constant'
+import { ONRAMP_API_KEY, PURCHASE_RAMP_URL } from 'util/constant'
 import { NetworkType } from 'util/network/network.util'
 import { trackClick } from 'util/analytics'
 
@@ -65,7 +65,7 @@ const BridgeAction = () => {
             data-testid="bridge-btn"
             label={<Heading variant="h3">Bridge</Heading>}
           />
-          {isMainnet && (
+          {isMainnet && ONRAMP_API_KEY ? (
             <BridgeActionButton
               outline
               onClick={() => {
@@ -75,7 +75,7 @@ const BridgeAction = () => {
               data-testid="connect-btn"
               label={<Heading variant="h3">Buy with Ramp Network</Heading>}
             />
-          )}
+          ) : null}
         </div>
       )}
     </BridgeActionContainer>

--- a/src/containers/Bridging/BridgeAction/index.tsx
+++ b/src/containers/Bridging/BridgeAction/index.tsx
@@ -40,6 +40,11 @@ const BridgeAction = () => {
     }
   }
 
+  console.log(`isMainnet && ONRAMP_API_KEY`, {
+    isMainnet,
+    ONRAMP_API_KEY,
+  })
+
   return (
     <BridgeActionContainer>
       {!accountEnabled ? (


### PR DESCRIPTION
Should not display the button buy with ramp network incase the api key is missing.